### PR TITLE
SG-12: add to secgen_metadata and make filterable from scenario.xml

### DIFF
--- a/config/scenario.xml
+++ b/config/scenario.xml
@@ -2,7 +2,7 @@
 	<!-- an example remote storage system, with a remotely exploitable vulnerability that can then be escalated to root -->
 	<system id="storageserver" os="linux" basebox="puppettest" url="" >
 		<vulnerabilities>
-			<vulnerability privilege="" access="" type="other" cve=""></vulnerability>
+			<vulnerability vector_string="Au:N/A:C"></vulnerability>
 		</vulnerabilities>
 		<!-- secure services will be provided, if matching insecure ones have not been selected -->
 		<!--<services>-->

--- a/lib/helpers/vulnerability_helper.rb
+++ b/lib/helpers/vulnerability_helper.rb
@@ -3,17 +3,22 @@ require_relative '../constants.rb'
 
 class VulnerabilityHelper
   def getVulnerabilityObject(vulnerability_hash)
-    return Vulnerability.new(
-        vulnerability_hash['type'],
-        vulnerability_hash['privilege'],
-        vulnerability_hash['access'],
-        vulnerability_hash['puppets'],
-        vulnerability_hash['details'],
-        vulnerability_hash['ports'],
-        vulnerability_hash['platform'],
-        vulnerability_hash['name'],
-        vulnerability_hash['cve'],
-        vulnerability_hash['files'],
-        vulnerability_hash['scripts'])
+    vulnerability = Vulnerability.new
+    vulnerability.type = vulnerability_hash['type'] if vulnerability_hash['type']
+    vulnerability.privilege = vulnerability_hash['privilege'] if vulnerability_hash['privilege']
+    vulnerability.access = vulnerability_hash['access'] if vulnerability_hash['access']
+    vulnerability.puppets = vulnerability_hash['puppets'] if vulnerability_hash['puppets']
+    vulnerability.details = vulnerability_hash['details'] if vulnerability_hash['details']
+    vulnerability.ports = vulnerability_hash['ports'] if vulnerability_hash['ports']
+    vulnerability.platform = vulnerability_hash['platform'] if vulnerability_hash['platform']
+    vulnerability.name = vulnerability_hash['name'] if vulnerability_hash['name']
+    vulnerability.cve = vulnerability_hash['cve'] if vulnerability_hash['cve']
+    vulnerability.files = vulnerability_hash['files'] if vulnerability_hash['files']
+    vulnerability.scripts = vulnerability_hash['scripts'] if vulnerability_hash['scripts']
+    vulnerability.difficulty = vulnerability_hash['difficulty'] if vulnerability_hash['difficulty']
+    vulnerability.cvss_rating = vulnerability_hash['cvss_rating'] if vulnerability_hash['cvss_rating']
+    vulnerability.cvss_score = vulnerability_hash['cvss_score'] if vulnerability_hash['cvss_score']
+    vulnerability.vector_string = vulnerability_hash['vector_string'] if vulnerability_hash['vector_string']
+    return vulnerability
   end
 end

--- a/lib/helpers/vulnerability_processor.rb
+++ b/lib/helpers/vulnerability_processor.rb
@@ -33,6 +33,20 @@ class VulnerabilityProcessor
           puts "Searching for vulnerability matching CVE: " + vulnerability_query.cve
           search_list.delete_if{|x| x.cve != vulnerability_query.cve}
         end
+        if vulnerability_query.difficulty.length > 0
+          puts "Searching for vulnerability matching difficulty: " + vulnerability_query.difficulty
+          search_list.delete_if{|x| x.difficulty != vulnerability_query.difficulty}
+        end
+
+        if vulnerability_query.cvss_rating.length > 0
+          puts "Searching for vulnerability matching cvss rating: " + vulnerability_query.cvss_rating
+          remove_by_cvss(vulnerability_query, search_list)
+        end
+
+        if vulnerability_query.vector_string.length > 0
+          puts "Searching for vulnerability based on vector string: " + vulnerability_query.vector_string
+          remove_by_vector(vulnerability_query, search_list)
+        end
 
         if search_list.length == 0
           puts VULN_NOT_FOUND
@@ -65,4 +79,39 @@ class VulnerabilityProcessor
 
       return vulnerabilities
     end
+
+    def remove_by_cvss (vulnerability_query, search_list)
+      puts case vulnerability_query.cvss_rating
+             when 'none' # 0.0
+               search_list.delete_if{|x| x.cvss_score.to_f > 0 }
+             when 'low' # 0.1 - 3.9
+               search_list.delete_if{|x| x.cvss_score.to_f == 0 or x.cvss_score.to_f > 4 }
+             when 'medium' # 4.0 - 6.9
+               search_list.delete_if{|x| x.cvss_score.to_f < 4 or x.cvss_score.to_f > 7 }
+             when 'high' # 7.0 - 8.9
+               search_list.delete_if{|x| x.cvss_score.to_f < 7 and x.cvss_score.to_f <= 9 }
+             when 'critical' # 9.0 - 10
+               search_list.delete_if{|x| x.cvss_score.to_f < 9 }
+           end
+    end
+
+    # method which removes vulnerabilities from the search_list based on vector string provided
+    # in the vulnerability_query (i.e. a user specified <vulnerability> in scenario.xml)
+    def remove_by_vector (query_vulnerability, search_list)
+
+    query_vector_hash = query_vulnerability.get_vector_hash
+
+    for query_vector_pair in query_vector_hash
+        search_list.delete_if{ |vulnerability|
+          search_vector_hash = vulnerability.get_vector_hash
+          search_vector_pair = search_vector_hash.assoc(query_vector_pair[0])
+          if search_vector_pair != nil
+            query_vector_pair[1] != search_vector_pair[1]
+          else
+            true
+          end
+        }
+     end
+  end
+
 end

--- a/lib/objects/vulnerability.rb
+++ b/lib/objects/vulnerability.rb
@@ -1,9 +1,9 @@
 require_relative('../constants.rb')
 
 class Vulnerability
-    attr_accessor :type, :privilege, :access ,:puppets, :details, :ports, :name, :cve, :files, :scripts, :platform
+    attr_accessor :type, :privilege, :access ,:puppets, :details, :ports, :name, :cve, :files, :scripts, :platform, :difficulty, :cvss_rating, :cvss_score, :vector_string
 
-    def initialize(type='', privilege='', access='', puppets=[], details='', ports=[], platform ='', name='', cve='', files=[], scripts=[])
+    def initialize(type='', privilege='', access='', puppets=[], details='', ports=[], platform ='', name='', cve='', files=[], scripts=[], difficulty ='', cvss_rating='', cvss_score='',vector_string='')
       @type = type
       @privilege = privilege
       @access = access
@@ -15,6 +15,20 @@ class Vulnerability
       @cve = cve
       @files = files
       @scripts = scripts
+      @difficulty = difficulty
+      @cvss_rating = cvss_rating
+      @cvss_score = cvss_score
+      @vector_string = vector_string
+
+      # Base Vector String:
+      # Example 1: 'AV:L/AC:H/Au:N/C:N/I:P/A:C'
+      # Access Vector: L = Local access, A = adjacent access, N = network access
+      # Access Complexity: H = High, M = Medium, L = Low
+      # Authentication: N = None required, S = Single instance, M = Multi instance
+      # Confidentiality Impact: N = None, P = Partial, C = Complete
+      # Integrity Impact: N = None, P = Partial, C = Complete
+      # Availabiliy Impact: N = None, P = Partial, C = Complete
+
     end
 
     def eql? other
@@ -34,4 +48,23 @@ class Vulnerability
       return vulnerability_path + '/puppet'
     end
 
+    def is_vector_populated
+      return vector_string.length > 0
+    end
+
+    #
+    def get_vector_hash
+      base_vector_string = vector_string # for example: "AV:L/AC:H/Au:N/C:N/I:P/A:C"
+      base_vector_array = base_vector_string.split('/') # split to get: ['AV:L', 'AC:H', 'Au:N','C:N', 'I:P', 'A:C']
+
+      # convert this into a hash map
+      base_vector_hash = {}
+      for vector_element_string in base_vector_array
+        vector_element_array = vector_element_string.split(':')
+        if vector_element_array[1] != nil
+          base_vector_hash.store(vector_element_array[0], vector_element_array[1])
+        end
+      end
+      return base_vector_hash
+    end
   end

--- a/lib/systemreader.rb
+++ b/lib/systemreader.rb
@@ -32,10 +32,14 @@ class SystemReader
 
 			system.css('vulnerabilities vulnerability').each do |v|
 				vulnerability = Vulnerability.new
-				vulnerability.privilege = v['privilege']
-				vulnerability.cve = v['cve']
-				vulnerability.access = v['access']
-				vulnerability.type = v['type']
+				# assign the value if the value is not nil (i.e. it's been specified in scenario.xml)
+				vulnerability.type = v['type'] if v['type']
+				vulnerability.privilege = v['privilege'] if v['privilege']
+				vulnerability.cve = v['cve'] if v['cve']
+				vulnerability.access = v['access'] if v['access']
+				vulnerability.difficulty = v['difficulty'] if v['difficulty']
+				vulnerability.cvss_rating = v['cvss_rating'] if v['cvss_rating']
+				vulnerability.vector_string = v['vector_string'] if v['vector_string']
 				vulns << vulnerability
 			end
 

--- a/modules/vulnerabilities/unix/ftp/vsftpd_234_backdoor/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/ftp/vsftpd_234_backdoor/secgen_metadata.xml
@@ -5,7 +5,11 @@
         access="remote"
         details="ftpbackdoor smiley face backdoor exploit"
         platform="unix"
-        name="vsftpd_234_backdoor">
+        name="vsftpd_234_backdoor"
+        msf_module="modules/exploits/unix/ftp/vsftpd_234_backdoor.rb"
+        difficulty="easy"
+        cvss_score="10"
+        vector_string="AV:N/AC:L/Au:N/C:C/I:C/A:C">
   <puppets>
     <puppet>install</puppet>
     <puppet>ftpbackdoor</puppet>

--- a/modules/vulnerabilities/unix/misc/distcc_exec/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/misc/distcc_exec/secgen_metadata.xml
@@ -5,7 +5,11 @@
         access="remote"
         details="distcc can be exploited by exploit/unix/misc/distcc_exec"
         platform="unix"
-        name="distcc_exec">
+        name="distcc_exec"
+        msf_module="modules/exploits/unix/misc/distcc_exec.rb"
+        difficulty="medium"
+        cvss_score="9.3"
+        vector_string="AV:N/AC:M/Au:N/C:C/I:C/A:C">
   <puppets>
     <puppet>distcc_exec</puppet>
   </puppets>


### PR DESCRIPTION
made a few changes:
* scenario.xml's vulnerability tag now only requires the attributes the user wants to filter by. Previously we required empty strings for the attributes that were not being used but this is no longer the case. e.g. `<vulnerability access="remote">`  
* added cvss scores and some logic to select by rating (none, low, medium, high, critical)
* added capability for users to filter by CVSS Vector String. The search is flexible and the user can specify any segment pair (or pairs) they require. e.g. `<vulnerability vector_string="AV:N/AC:L">` for a vulnerability with a **N**etwork **A**ttack **V**ector and **L**ow **A**ccess **C**omplexity.

cheers