### PR TITLE
removes wordpress in vagrantbase

### DIFF
--- a/lib/templates/vagrantbase.erb
+++ b/lib/templates/vagrantbase.erb
@@ -53,12 +53,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     <% end %>
 
-    config.vm.provision "puppet" do |wordpress|
-    wordpress.module_path = "<%="#{ROOT_DIR}/mount/puppet/module"%>"
-    wordpress.manifests_path = "<%="#{ROOT_DIR}/mount/puppet/manifest"%>"
-    wordpress.manifest_file = "wordpress.pp"
-    end
-
     # clean up script which clears history from the VMs and clobs files together
     config.vm.provision "puppet" do |cleanup|
     cleanup.module_path = "<%="#{ROOT_DIR}/mount/puppet/module"%>"


### PR DESCRIPTION
Removes to make main repo working - mechanism for selecting a site hasnt been started yet.