### PR TITLE
post-update fixes

### DIFF
--- a/lib/helpers/gem_exec.rb
+++ b/lib/helpers/gem_exec.rb
@@ -16,7 +16,7 @@ class GemExec
       gem_path = Gem.bin_path(gem_name, gem_name, version)
     rescue Exception => e
       # test if the program is already installed via package management
-      gem_path = `which #{gem_name}`
+      gem_path = `which #{gem_name}`.chomp
       unless File.file? gem_path
         Print.err "Executable for #{gem_name} not found: #{e.message}"
         # vagrant can be executed via the gem path, but not installed this way

--- a/modules/vulnerabilities/unix/nfs/nfs_overshare/manifests/config.pp
+++ b/modules/vulnerabilities/unix/nfs/nfs_overshare/manifests/config.pp
@@ -1,4 +1,4 @@
-class mountable_nfs::config {
+class nfs_overshare::config {
 
   package { ['nfs-kernel-server', 'nfs-common', 'portmap']:
       ensure => installed
@@ -11,7 +11,7 @@ class mountable_nfs::config {
     owner   => 'root',
     group   => 'root',
     mode    => '0777',
-    content  => template('mountable_nfs/exports.erb')
+    content  => template('nfs_overshare/exports.erb')
   }
 
   exec { "exportfs":

--- a/modules/vulnerabilities/unix/nfs/nfs_overshare/nfs_overshare.pp
+++ b/modules/vulnerabilities/unix/nfs/nfs_overshare/nfs_overshare.pp
@@ -1,1 +1,1 @@
-include mountable_nfs::config
+include nfs_overshare::config


### PR DESCRIPTION
Added a chomp to gem_exec's path evaluation, was leaving a trailing newline + evaluating /usr/bin/vagrant\n as false when the /usr/bin/vagrant file existed.


![image](https://cloud.githubusercontent.com/assets/3964474/15926662/4425033e-2e35-11e6-9430-52f753b87736.png)


![image](https://cloud.githubusercontent.com/assets/3964474/15926673/4c265ec0-2e35-11e6-8230-f9d08888e379.png)


![image](https://cloud.githubusercontent.com/assets/3964474/15926679/5363bafc-2e35-11e6-9e9d-cd8c2654321b.png)

