### PR TITLE
Adds utf-8 encoding so older systems will not fail on US-ASCII codes

### DIFF
--- a/lib/readers/system_reader.rb
+++ b/lib/readers/system_reader.rb
@@ -1,3 +1,6 @@
+#!/bin/env ruby
+# encoding: utf-8
+
 require 'nokogiri'
 
 require_relative '../objects/system'

--- a/lib/readers/system_reader.rb
+++ b/lib/readers/system_reader.rb
@@ -1,6 +1,3 @@
-#!/bin/env ruby
-# encoding: utf-8
-
 require 'nokogiri'
 
 require_relative '../objects/system'
@@ -61,7 +58,7 @@ class SystemReader
         Print.verbose " #{module_node.name}, selecting based on:"
         module_selector.attributes.each do |attr|
           if attr[0] && attr[1] && attr[0].to_s != "module_type"
-            Print.verbose "  ├ #{attr[0].to_s} ~= #{attr[1].to_s}"
+            Print.verbose "  - #{attr[0].to_s} ~= #{attr[1].to_s}"
           end
         end
 


### PR DESCRIPTION
Fails on some characters, due to the us-ascii coding on those characters, enforcing utf-8 encoding should stop this entirely.