### PR TITLE
Update service that performs the repository update for the created vm.

### DIFF
--- a/modules/services/unix/update/unix_update/manifests/unix.pp
+++ b/modules/services/unix/update/unix_update/manifests/unix.pp
@@ -1,0 +1,34 @@
+class unix_update::unix{
+  case $operatingsystem {
+    'Debian': {
+      exec { 'update':
+        command => "/usr/bin/apt-get update"
+      }
+    }
+    'Ubuntu': {
+      exec { 'update':
+        command => "/usr/bin/apt-get update"
+      }
+    }
+    'RedHat': {
+      exec { 'update':
+        command => "yum update"
+      }
+    }
+    'CentOS': {
+      exec { 'update':
+        command => "su -c 'yum update'"
+      }
+    }
+    'Solaris': {
+      exec { 'update':
+        command => "pkg update"
+      }
+    }
+    # 'MacOS': {
+    #   exec { 'update':
+    #     command => ""
+    #   }
+    # }
+  }
+}

--- a/modules/services/unix/update/unix_update/secgen_metadata.xml
+++ b/modules/services/unix/update/unix_update/secgen_metadata.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+
+<service xmlns="http://www.github/cliffe/SecGen/service"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.github/cliffe/SecGen/service">
+  <name>Unix_update_service</name>
+  <author>Jason Keighley</author>
+  <module_license>Apache v2</module_license>
+  <description>An update module for unix</description>
+
+  <type>update</type>
+  <platform>linux</platform>
+
+  <!--optional details-->
+  <reference></reference>
+  <software_name>unix_update</software_name>
+  <software_license>Apache v2</software_license>
+
+  <!--Cannot co-exist with other apache installations-->
+  <conflict>
+    <software_name>windows_update</software_name>
+  </conflict>
+
+</service>

--- a/modules/services/unix/update/unix_update/unix_update.pp
+++ b/modules/services/unix/update/unix_update/unix_update.pp
@@ -1,0 +1,1 @@
+include unix_update::unix

--- a/modules/services/windows/update/windows_update/CHANGELOG.md
+++ b/modules/services/windows/update/windows_update/CHANGELOG.md
@@ -1,0 +1,17 @@
+## 2016-03-29 Release 1.1.0
+- Deprecate mixed case parameters
+
+## 2015-03-19 Release 1.0.1
+- fixing bug in puppet-community release
+
+## 2015-03-19 Release 1.0.0
+- first puppet-community supported version
+
+## 2015-01-16 Release 0.1.0
+- support for windows 2012
+
+## 2013-05-01 Release 0.0.2
+- less restrictive dependency on stdlib
+
+## 2013-04-26 Release 0.0.1
+- initial version

--- a/modules/services/windows/update/windows_update/CONTRIBUTING.md
+++ b/modules/services/windows/update/windows_update/CONTRIBUTING.md
@@ -1,0 +1,234 @@
+Checklist (and a short version for the impatient)
+=================================================
+
+  * Commits:
+
+    - Make commits of logical units.
+
+    - Check for unnecessary whitespace with "git diff --check" before
+      committing.
+
+    - Commit using Unix line endings (check the settings around "crlf" in
+      git-config(1)).
+
+    - Do not check in commented out code or unneeded files.
+
+    - The first line of the commit message should be a short
+      description (50 characters is the soft limit, excluding ticket
+      number(s)), and should skip the full stop.
+
+    - Associate the issue in the message. The first line should include
+      the issue number in the form "(#XXXX) Rest of message".
+
+    - The body should provide a meaningful commit message, which:
+
+      - uses the imperative, present tense: "change", not "changed" or
+        "changes".
+
+      - includes motivation for the change, and contrasts its
+        implementation with the previous behavior.
+
+    - Make sure that you have tests for the bug you are fixing, or
+      feature you are adding.
+
+    - Make sure the test suites passes after your commit:
+      `bundle exec rspec spec/acceptance` More information on [testing](#Testing) below
+
+    - When introducing a new feature, make sure it is properly
+      documented in the README.md
+
+  * Submission:
+
+    * Pre-requisites:
+
+      - Sign the [Contributor License Agreement](https://cla.puppetlabs.com/)
+
+      - Make sure you have a [GitHub account](https://github.com/join)
+
+      - [Create a ticket](http://projects.puppetlabs.com/projects/modules/issues/new), or [watch the ticket](http://projects.puppetlabs.com/projects/modules/issues) you are patching for.
+
+    * Preferred method:
+
+      - Fork the repository on GitHub.
+
+      - Push your changes to a topic branch in your fork of the
+        repository. (the format ticket/1234-short_description_of_change is
+        usually preferred for this project).
+
+      - Submit a pull request to the repository in the puppetlabs
+        organization.
+
+The long version
+================
+
+  1.  Make separate commits for logically separate changes.
+
+      Please break your commits down into logically consistent units
+      which include new or changed tests relevant to the rest of the
+      change.  The goal of doing this is to make the diff easier to
+      read for whoever is reviewing your code.  In general, the easier
+      your diff is to read, the more likely someone will be happy to
+      review it and get it into the code base.
+
+      If you are going to refactor a piece of code, please do so as a
+      separate commit from your feature or bug fix changes.
+
+      We also really appreciate changes that include tests to make
+      sure the bug is not re-introduced, and that the feature is not
+      accidentally broken.
+
+      Describe the technical detail of the change(s).  If your
+      description starts to get too long, that is a good sign that you
+      probably need to split up your commit into more finely grained
+      pieces.
+
+      Commits which plainly describe the things which help
+      reviewers check the patch and future developers understand the
+      code are much more likely to be merged in with a minimum of
+      bike-shedding or requested changes.  Ideally, the commit message
+      would include information, and be in a form suitable for
+      inclusion in the release notes for the version of Puppet that
+      includes them.
+
+      Please also check that you are not introducing any trailing
+      whitespace or other "whitespace errors".  You can do this by
+      running "git diff --check" on your changes before you commit.
+
+  2.  Sign the Contributor License Agreement
+
+      Before we can accept your changes, we do need a signed Puppet
+      Labs Contributor License Agreement (CLA).
+
+      You can access the CLA via the [Contributor License Agreement link](https://cla.puppetlabs.com/)
+
+      If you have any questions about the CLA, please feel free to
+      contact Puppet Labs via email at cla-submissions@puppetlabs.com.
+
+  3.  Sending your patches
+
+      To submit your changes via a GitHub pull request, we _highly_
+      recommend that you have them on a topic branch, instead of
+      directly on "master".
+      It makes things much easier to keep track of, especially if
+      you decide to work on another thing before your first change
+      is merged in.
+
+      GitHub has some pretty good
+      [general documentation](http://help.github.com/) on using
+      their site.  They also have documentation on
+      [creating pull requests](http://help.github.com/send-pull-requests/).
+
+      In general, after pushing your topic branch up to your
+      repository on GitHub, you can switch to the branch in the
+      GitHub UI and click "Pull Request" towards the top of the page
+      in order to open a pull request.
+
+
+  4.  Update the related GitHub issue.
+
+      If there is a GitHub issue associated with the change you
+      submitted, then you should update the ticket to include the
+      location of your branch, along with any other commentary you
+      may wish to make.
+
+Testing
+=======
+
+Getting Started
+---------------
+
+Our puppet modules provide [`Gemfile`](./Gemfile)s which can tell a ruby
+package manager such as [bundler](http://bundler.io/) what Ruby packages,
+or Gems, are required to build, develop, and test this software.
+
+Please make sure you have [bundler installed](http://bundler.io/#getting-started)
+on your system, then use it to install all dependencies needed for this project,
+by running
+
+```shell
+% bundle install
+Fetching gem metadata from https://rubygems.org/........
+Fetching gem metadata from https://rubygems.org/..
+Using rake (10.1.0)
+Using builder (3.2.2)
+-- 8><-- many more --><8 --
+Using rspec-system-puppet (2.2.0)
+Using serverspec (0.6.3)
+Using rspec-system-serverspec (1.0.0)
+Using bundler (1.3.5)
+Your bundle is complete!
+Use `bundle show [gemname]` to see where a bundled gem is installed.
+```
+
+NOTE some systems may require you to run this command with sudo.
+
+If you already have those gems installed, make sure they are up-to-date:
+
+```shell
+% bundle update
+```
+
+With all dependencies in place and up-to-date we can now run the tests:
+
+```shell
+% rake spec
+```
+
+This will execute all the [rspec tests](http://rspec-puppet.com/) tests
+under [spec/defines](./spec/defines), [spec/classes](./spec/classes),
+and so on. rspec tests may have the same kind of dependencies as the
+module they are testing. While the module defines in its [Modulefile](./Modulefile),
+rspec tests define them in [.fixtures.yml](./fixtures.yml).
+
+Some puppet modules also come with [beaker](https://github.com/puppetlabs/beaker)
+tests. These tests spin up a virtual machine under
+[VirtualBox](https://www.virtualbox.org/)) with, controlling it with
+[Vagrant](http://www.vagrantup.com/) to actually simulate scripted test
+scenarios. In order to run these, you will need both of those tools
+installed on your system.
+
+You can run them by issuing the following command
+
+```shell
+% rake spec_clean
+% rspec spec/acceptance
+```
+
+This will now download a pre-fabricated image configured in the [default node-set](./spec/acceptance/nodesets/default.yml),
+install puppet, copy this module and install its dependencies per [spec/spec_helper_acceptance.rb](./spec/spec_helper_acceptance.rb)
+and then run all the tests under [spec/acceptance](./spec/acceptance).
+
+Writing Tests
+-------------
+
+XXX getting started writing tests.
+
+If you have commit access to the repository
+===========================================
+
+Even if you have commit access to the repository, you will still need to
+go through the process above, and have someone else review and merge
+in your changes.  The rule is that all changes must be reviewed by a
+developer on the project (that did not write the code) to ensure that
+all changes go through a code review process.
+
+Having someone other than the author of the topic branch recorded as
+performing the merge is the record that they performed the code
+review.
+
+
+Additional Resources
+====================
+
+* [Getting additional help](http://projects.puppetlabs.com/projects/puppet/wiki/Getting_Help)
+
+* [Writing tests](http://projects.puppetlabs.com/projects/puppet/wiki/Development_Writing_Tests)
+
+* [Patchwork](https://patchwork.puppetlabs.com)
+
+* [Contributor License Agreement](https://projects.puppetlabs.com/contributor_licenses/sign)
+
+* [General GitHub documentation](http://help.github.com/)
+
+* [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
+

--- a/modules/services/windows/update/windows_update/Gemfile
+++ b/modules/services/windows/update/windows_update/Gemfile
@@ -1,0 +1,37 @@
+#  Copyright 2014 Puppet Community
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+source "https://rubygems.org"
+
+group :test do
+  gem "rake"
+  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
+  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "rspec-puppet-facts"
+  gem "rspec", "< 3.2.0", { "platforms" => ["ruby_18"] }
+end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+end
+
+group :system_tests do
+  gem "beaker"
+  gem "beaker-rspec"
+end

--- a/modules/services/windows/update/windows_update/Guardfile
+++ b/modules/services/windows/update/windows_update/Guardfile
@@ -1,0 +1,5 @@
+notification :off
+
+guard 'rake', :task => 'test' do
+  watch(%r{^manifests\/(.+)\.pp$})
+end

--- a/modules/services/windows/update/windows_update/LICENSE
+++ b/modules/services/windows/update/windows_update/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2014 Liam Bennett (liamjbennett@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/modules/services/windows/update/windows_update/README.md
+++ b/modules/services/windows/update/windows_update/README.md
@@ -1,0 +1,107 @@
+# puppet-windows_autoupdate
+
+#### Table of Contents
+
+1. [Overview](#overview)
+2. [Module Description - What is the windows_autoupdate module?](#module-description)
+3. [Setup - The basics of getting started with windows_autoupdate](#setup)
+    * [What windows_autoupdate affects](#what-autoupdates-affects)
+    * [Setup requirements](#setup-requirements)
+    * [Beginning with windows_autoupdate](#beginning-with-autoupdates)
+4. [Usage - Configuration options and additional functionality](#usage)
+5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+5. [Limitations - OS compatibility, etc.](#limitations)
+6. [Development - Guide for contributing to the module](#development)
+
+## Overview
+
+Puppet module for managing [Microsoft Windows Automatic Updates](http://support.microsoft.com/kb/328010).
+
+[![Build Status](https://travis-ci.org/voxpupuli/puppet-windows_autoupdate.svg?branch=master)](https://travis-ci.org/voxpupuli/puppet-windows_autoupdate)
+
+## Module Description
+
+This module configures all the relevant windows registry keys used to manage windows automatic update settings on your windows machine.
+
+## Setup
+
+### What autoupdates affects
+
+* Configures registry keys/values
+
+### Beginning with autoupdate
+
+Manage autoupdates with default settings:
+
+```puppet
+   include windows_autoupdate
+```
+
+Disable auto updates:
+
+```puppet
+   class { 'windows_autoupdate': noAutoUpdate => '1' }
+```
+
+## Usage
+
+### Classes and Defined Types
+
+#### Class: `windows_autoupdate`
+
+The autoupdate module primary classes, `windows_autoupdate`, configures all the registry settings required to manage auto updates.
+
+**Parameters within `windows_autoupdates`:**
+##### `noAutoUpdate`
+
+* 0 - Enable Automatic Updates (Default)
+* 1 - Disable Automatic Updates
+
+##### `aUOptions`
+
+* 2 - Notify for download and notify for install
+* 3 - Auto download and notify for install
+* 4 - Auto download and schedule the install
+
+##### `scheduledInstallDay`
+
+* 0 - Install every day
+* 1 to 7 - Install on specific day of the week from Sunday (1) to Saturday (7).
+
+##### `scheduledInstallTime`
+
+* 0 to 23 - Install time of day in 24-hour format
+
+##### `useWUServer`
+
+* 1 to use custom update server
+
+##### `rescheduleWaitTime`
+
+* The number of minutes to wait after service start time before performing the installation.
+
+##### `noAutoRebootWithLoggedOnUsers`
+
+* 1 to prevent automatic reboot while users are logged on.
+
+## Reference
+
+### Classes
+
+#### Public Classes
+
+* [`windows_autoupdates`](#class_autoupdates): Guides the basic management of windows auto update settings.
+
+## Limitations
+
+This module is tested on the following platforms:
+
+* Windows 2008 R2
+
+It is tested with the OSS version of Puppet only.
+
+## Development
+
+### Contributing
+
+Please read CONTRIBUTING.md for full details on contributing to this project.

--- a/modules/services/windows/update/windows_update/Rakefile
+++ b/modules/services/windows/update/windows_update/Rakefile
@@ -1,0 +1,55 @@
+#  Copyright 2014 Puppet Community
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+
+# These two gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
+
+PuppetLint.configuration.relative = true
+PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.fail_on_warnings = true
+
+# Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
+# http://puppet-lint.com/checks/class_parameter_defaults/
+PuppetLint.configuration.send('disable_class_parameter_defaults')
+# http://puppet-lint.com/checks/class_inherits_from_params_class/
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetSyntax.exclude_paths = exclude_paths
+
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+]

--- a/modules/services/windows/update/windows_update/checksums.json
+++ b/modules/services/windows/update/windows_update/checksums.json
@@ -1,0 +1,18 @@
+{
+  "CHANGELOG.md": "67b60aea42ff4584c2bc30c036db8237",
+  "CONTRIBUTING.md": "d911815dd7d0d90b90bb35382a6e3298",
+  "Gemfile": "b7e8516f82d1f3a3ba932a94b569db78",
+  "Guardfile": "3ae8d9a61b870350cc1c8e0d6a9a36e7",
+  "LICENSE": "a2b09ed4caa4c6b8fb25c294f01b3fc2",
+  "README.md": "3def75e20d4bc80fb702e80ceb7725f2",
+  "Rakefile": "f8ca8f8a88de0adc8002b5a93b9dd1d6",
+  "manifests/init.pp": "a6b51ccbf3401239139304ed272cd30e",
+  "manifests/params.pp": "0fd056d1af4496a3c58786336289dcce",
+  "metadata.json": "d0c5880bd6a8ae56496facfc3803a5d3",
+  "spec/acceptance/nodesets/windows-2008R2-serverstandard-x64.yml": "50219eac8138cc5d1018c8a8b0ff2cdb",
+  "spec/classes/coverage_spec.rb": "5b6dfa0dd426aca0ccfae23c0a629f0b",
+  "spec/classes/windows_autoupdate_spec.rb": "8d34d7d02f06c9add9d3cdc1f698fe47",
+  "spec/spec.opts": "a600ded995d948e393fbe2320ba8e51c",
+  "spec/spec_helper.rb": "0db89c9a486df193c0e40095422e19dc",
+  "spec/spec_helper_acceptance.rb": "6891c7598940cfc71c2d8e6382b4780b"
+}

--- a/modules/services/windows/update/windows_update/manifests/init.pp
+++ b/modules/services/windows/update/windows_update/manifests/init.pp
@@ -1,0 +1,189 @@
+# Author::    Liam Bennett (mailto:liamjbennett@gmail.com)
+# Copyright:: Copyright (c) 2014 Liam Bennett
+# License::   MIT
+
+# == Class: windows_autoupdate
+#
+# Module to mananage the configuration of a machines autoupdate settings
+#
+# === Requirements/Dependencies
+#
+# Currently reequires the puppetlabs/stdlib module on the Puppet Forge in
+# order to validate much of the the provided configuration.
+#
+# === Parameters
+#
+# [*no_auto_update*]
+# Ensuring the state of automatic updates.
+# 0: Automatic Updates is enabled (default)
+# 1: Automatic Updates is disabled.
+#
+# [*au_options*]
+# The option to configure what to do when an update is avaliable
+# 1: Keep my computer up to date has been disabled in Automatic Updates.
+# 2: Notify of download and installation.
+# 3: Automatically download and notify of installation.
+# 4: Automatically download and scheduled installation.
+#
+# [*scheduled_install_day*]
+# The day of the week to install updates.
+# 0: Every day.
+# 1 through 7: The days of the week from Sunday (1) to Saturday (7).
+#
+# [*scheduled_install_time*]
+# The time of day (in 24hr format) when to install updates.
+#
+# [*use_wuserver*]
+# If set to 1, windows autoupdates will use a local WSUS server rather than windows update.
+#
+# [*reschedule_wait_time*]
+# The time period to wait between the time Automatic Updates starts and the time it begins installations
+# where the scheduled times have passed. The time is set in minutes from 1 to 60
+#
+# [*no_auto_reboot_with_logged_on_users*]
+# If set to 1, Automatic Updates does not automatically restart a computer while users are logged on.
+#
+# === Examples
+#
+# Manage autoupdates with windows default settings:
+#
+#   include windows_autoupdate
+#
+# Disable auto updates (don't do this!):
+#
+#   class { 'windows_autoupdate': no_auto_update => '1' }
+#
+class windows_autoupdate(
+  $noAutoUpdate                  = $windows_autoupdate::params::noAutoUpdate,
+  $aUOptions                     = $windows_autoupdate::params::aUOptions,
+  $scheduledInstallDay           = $windows_autoupdate::params::scheduledInstallDay,
+  $scheduledInstallTime          = $windows_autoupdate::params::scheduledInstallTime,
+  $useWUServer                   = $windows_autoupdate::params::useWUServer,
+  $rescheduleWaitTime            = $windows_autoupdate::params::rescheduleWaitTime,
+  $noAutoRebootWithLoggedOnUsers = $windows_autoupdate::params::noAutoRebootWithLoggedOnUsers,
+
+  $au_options                          = $windows_autoupdate::params::au_options,
+  $no_auto_reboot_with_logged_on_users = $windows_autoupdate::params::no_auto_reboot_with_logged_on_users,
+  $no_auto_update                      = $windows_autoupdate::params::no_auto_update,
+  $reschedule_wait_time                = $windows_autoupdate::params::reschedule_wait_time,
+  $scheduled_install_day               = $windows_autoupdate::params::scheduled_install_day,
+  $scheduled_install_time              = $windows_autoupdate::params::scheduled_install_time,
+  $use_wuserver                        = $windows_autoupdate::params::use_wuserver,
+) inherits windows_autoupdate::params {
+
+  if $aUOptions {
+    warning("${module_name}: The use of aUOptions is deprecated. Use au_options instead.")
+    $real_au_options = $aUOptions
+  } else {
+    $real_au_options = $au_options
+  }
+
+  if $noAutoRebootWithLoggedOnUsers {
+    warning("${module_name}: The use of noAutoRebootWithLoggedOnUsers is deprecated. Use no_auto_reboot_with_logged_on_users instead.")
+    $real_no_auto_reboot_with_logged_on_users = $noAutoRebootWithLoggedOnUsers
+  } else {
+    $real_no_auto_reboot_with_logged_on_users = $no_auto_reboot_with_logged_on_users
+  }
+
+  if $noAutoUpdate {
+    warning("${module_name}: The use of noAutoUpdate is deprecated. Use no_auto_update instead.")
+    $real_no_auto_update = $noAutoUpdate
+  } else {
+    $real_no_auto_update = $no_auto_update
+  }
+
+  if $rescheduleWaitTime {
+    warning("${module_name}: The use of rescheduleWaitTime is deprecated. Use reschedule_wait_time instead.")
+    $real_reschedule_wait_time = $rescheduleWaitTime
+  } else {
+    $real_reschedule_wait_time = $reschedule_wait_time
+  }
+
+  if $scheduledInstallDay {
+    warning("${module_name}: The use of scheduledInstallDay is deprecated. Use scheduled_install_day instead.")
+    $real_scheduled_install_day = $scheduledInstallDay
+  } else {
+    $real_scheduled_install_day = $scheduled_install_day
+  }
+
+  if $scheduledInstallTime {
+    warning("${module_name}: The use of cheduledInstallTime is deprecated. Use scheduled_install_time instead.")
+    $real_scheduled_install_time = $scheduledInstallTime
+  } else {
+    $real_scheduled_install_time = $scheduled_install_time
+  }
+
+  if $useWUServer {
+    warning("${module_name}: The use of useWUServer is deprecated. Use use_wuserver instead.")
+    $real_use_wuserver = $useWUServer
+  } else {
+    $real_use_wuserver = $use_wuserver
+  }
+
+  validate_re($real_no_auto_update,['^[0,1]$'])
+  validate_re($real_au_options,['^[1-4]$'])
+  validate_re($real_scheduled_install_day,['^[0-7]$'])
+  validate_re($real_scheduled_install_time,['^(2[0-3]|1?[0-9])$'])
+  validate_re($real_use_wuserver,['^[0,1]$'])
+  validate_re($real_reschedule_wait_time,['^(60|[1-5][0-9]|[1-9])$'])
+  validate_re($real_no_auto_reboot_with_logged_on_users,['^[0,1]$'])
+
+  service { 'wuauserv':
+    ensure    => 'running',
+    enable    => true,
+    subscribe => Registry_value['NoAutoUpdate','AUOptions','ScheduledInstallDay', 'ScheduledInstallTime','UseWUServer','RescheduleWaitTime','NoAutoRebootWithLoggedOnUsers']
+  }
+
+  registry_key { $windows_autoupdate::params::p_reg_key:
+    ensure => present
+  }
+
+  registry_value { 'NoAutoUpdate':
+    ensure => present,
+    path   => "${windows_autoupdate::params::p_reg_key}\\NoAutoUpdate",
+    type   => 'dword',
+    data   => $real_no_auto_update
+  }
+
+  registry_value { 'AUOptions':
+    ensure => present,
+    path   => "${windows_autoupdate::params::p_reg_key}\\AUOptions",
+    type   => 'dword',
+    data   => $real_au_options
+  }
+
+  registry_value { 'ScheduledInstallDay':
+    ensure => present,
+    path   => "${windows_autoupdate::params::p_reg_key}\\ScheduledInstallDay",
+    type   => 'dword',
+    data   => $real_scheduled_install_day
+  }
+
+  registry_value { 'ScheduledInstallTime':
+    ensure => present,
+    path   => "${windows_autoupdate::params::p_reg_key}\\ScheduledInstallTime",
+    type   => 'dword',
+    data   => $real_scheduled_install_time
+  }
+
+  registry_value { 'UseWUServer':
+    ensure => present,
+    path   => "${windows_autoupdate::params::p_reg_key}\\UseWUServer",
+    type   => 'dword',
+    data   => $real_use_wuserver
+  }
+
+  registry_value { 'RescheduleWaitTime':
+    ensure => present,
+    path   => "${windows_autoupdate::params::p_reg_key}\\RescheduleWaitTime",
+    type   => 'dword',
+    data   => $real_reschedule_wait_time
+  }
+
+  registry_value { 'NoAutoRebootWithLoggedOnUsers':
+    ensure => present,
+    path   => "${windows_autoupdate::params::p_reg_key}\\NoAutoRebootWithLoggedOnUsers",
+    type   => 'dword',
+    data   => $real_no_auto_reboot_with_logged_on_users
+  }
+}

--- a/modules/services/windows/update/windows_update/manifests/params.pp
+++ b/modules/services/windows/update/windows_update/manifests/params.pp
@@ -1,0 +1,34 @@
+# Author::    Liam Bennett (mailto:liamjbennett@gmail.com)
+# Copyright:: Copyright (c) 2014 Liam Bennett
+# License::   MIT
+
+# == Class windows_autoupdate::params
+#
+# This private class is meant to be called from `windows_autoupdate`
+# It sets variables according to platform
+#
+class windows_autoupdate::params {
+
+  $noAutoUpdate = undef
+  $aUOptions = undef
+  $scheduledInstallDay = undef
+  $scheduledInstallTime = undef
+  $useWUServer = undef
+  $rescheduleWaitTime = undef
+  $noAutoRebootWithLoggedOnUsers = undef
+
+  $au_options                          = '4'
+  $no_auto_reboot_with_logged_on_users = '0'
+  $no_auto_update                      = '0'
+  $reschedule_wait_time                = '10'
+  $scheduled_install_day               = '1'
+  $scheduled_install_time              = '10'
+  $use_wuserver                        = '0'
+
+  if $::operatingsystemrelease == 'Server 2012' {
+    $p_reg_key = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update'
+  } else {
+    $p_reg_key = 'HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU'
+  }
+
+}

--- a/modules/services/windows/update/windows_update/metadata.json
+++ b/modules/services/windows/update/windows_update/metadata.json
@@ -1,0 +1,25 @@
+{
+  "name": "puppet-windows_autoupdate",
+  "version": "1.1.0",
+  "author": "puppet",
+  "summary": "Module for managing windows automatic updates",
+  "license": "Apache-2.0",
+  "source": "https://github.com/voxpupuli/puppet-windows_autoupdate",
+  "project_page": "https://github.com/voxpupuli/puppet-windows_autoupdate",
+  "issues_url": "https://github.com/voxpupuli/puppet-windows_autoupdate/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "windows",
+      "operatingsystemrelease": [
+        "2008",
+        "2008 R2",
+        "2012",
+        "2012 R2"
+      ]
+    }
+  ],
+  "dependencies": [
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.0.0 <5.0.0"},
+    {"name":"puppetlabs/registry","version_requirement":">= 1.0.0 <2.0.0"}
+  ]
+}

--- a/modules/services/windows/update/windows_update/secgen_metadata.xml
+++ b/modules/services/windows/update/windows_update/secgen_metadata.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+
+<service xmlns="http://www.github/cliffe/SecGen/service"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.github/cliffe/SecGen/service">
+  <name>Windows_automatic_update_control_service</name>
+  <author>Liam Bennett</author>
+  <module_license>MIT</module_license>
+  <description>An update module for windows</description>
+
+  <type>update</type>
+  <platform>linux</platform>
+
+  <!--optional details-->
+  <reference></reference>
+  <software_name>windows_update</software_name>
+  <software_license>MIT</software_license>
+
+  <!--Cannot co-exist with other apache installations-->
+  <conflict>
+    <software_name>unix_update</software_name>
+  </conflict>
+
+</service>

--- a/modules/services/windows/update/windows_update/spec/acceptance/nodesets/windows-2008R2-serverstandard-x64.yml
+++ b/modules/services/windows/update/windows_update/spec/acceptance/nodesets/windows-2008R2-serverstandard-x64.yml
@@ -1,0 +1,14 @@
+HOSTS:
+  win-2008R2-std:
+    roles:
+      - default
+      - agent
+    platform: windows-server-amd64
+    box: opentable/win-2008r2-standard-amd64-nocm
+    hypervisor: vagrant
+    user: vagrant
+    ip: '10.255.33.129'
+    communicator: bitvise
+CONFIG:
+  log_level: verbose
+  type: git

--- a/modules/services/windows/update/windows_update/spec/classes/coverage_spec.rb
+++ b/modules/services/windows/update/windows_update/spec/classes/coverage_spec.rb
@@ -1,0 +1,1 @@
+at_exit { RSpec::Puppet::Coverage.report! }

--- a/modules/services/windows/update/windows_update/spec/classes/windows_autoupdate_spec.rb
+++ b/modules/services/windows/update/windows_update/spec/classes/windows_autoupdate_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+$p_reg_key = 'HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU'
+
+$defaults = { 'no_auto_update' => '0', 'au_options' => '4', 'scheduled_install_day' => '1',
+              'scheduled_install_time' => '1', 'use_wuserver' => '0', 'reschedule_wait_time' => '10',
+              'no_auto_reboot_with_logged_on_users' => '0' }
+
+$invalid_params = { 'no_auto_update' => '100', 'au_options' => '100', 'scheduled_install_day' => '100',
+                    'scheduled_install_time' => '100', 'use_wuserver' => '100', 'reschedule_wait_time' => '100',
+                    'no_auto_reboot_with_logged_on_users' => '100' }
+
+describe 'windows_autoupdate', :type => :class do
+
+  let :facts do
+    { :operatingsystemrelease => '2008 R2' }
+  end
+
+  context 'basic requirements' do
+    let :params do
+      { :no_auto_update => '0', :au_options => '4', :scheduled_install_day => '1',
+        :scheduled_install_time => '1', :use_wuserver => '0', :reschedule_wait_time => '10',
+        :no_auto_reboot_with_logged_on_users => '0' }
+    end
+    it { should contain_registry_key($p_reg_key ) }
+
+    it { should contain_registry_value('NoAutoUpdate').with(
+        'ensure'  => 'present',
+        'path'    => "#{$p_reg_key}\\NoAutoUpdate",
+        'type'    => 'dword',
+        'data'    => 0
+    )}
+
+    it { should contain_registry_value('AUOptions').with(
+        'ensure'  => 'present',
+        'path'    => "#{$p_reg_key}\\AUOptions",
+        'type'    => 'dword',
+        'data'    => 4
+    )}
+
+    it { should contain_registry_value('ScheduledInstallDay').with(
+        'ensure'  => 'present',
+        'path'    => "#{$p_reg_key}\\ScheduledInstallDay",
+        'type'    => 'dword',
+        'data'    => 1
+    )}
+
+    it { should contain_registry_value('UseWUServer').with(
+        'ensure'  => 'present',
+        'path'    => "#{$p_reg_key}\\UseWUServer",
+        'type'    => 'dword',
+        'data'    => 0
+    )}
+
+    it { should contain_registry_value('RescheduleWaitTime').with(
+        'ensure'  => 'present',
+        'path'    => "#{$p_reg_key}\\RescheduleWaitTime",
+        'type'    => 'dword',
+        'data'    => 10
+    )}
+
+    it { should contain_registry_value('NoAutoRebootWithLoggedOnUsers').with(
+        'ensure'  => 'present',
+        'path'    => "#{$p_reg_key}\\NoAutoRebootWithLoggedOnUsers",
+        'type'    => 'dword',
+        'data'    => 0
+    )}
+
+    it { should contain_service('wuauserv').with(
+      'ensure' => 'running',
+      'enable' => 'true'
+    )}
+  end
+
+  context "passing custom params" do
+    let :params do
+      { :no_auto_update => '1', :au_options => '1', :scheduled_install_day => '5',
+        :scheduled_install_time => '1', :use_wuserver => '1', :reschedule_wait_time => '1',
+        :no_auto_reboot_with_logged_on_users => '1' }
+    end
+    it { should contain_registry_value('NoAutoUpdate').with('data' => '1')}
+    it { should contain_registry_value('AUOptions').with('data' => '1')}
+    it { should contain_registry_value('ScheduledInstallDay').with('data' => '5')}
+    it { should contain_registry_value('ScheduledInstallTime').with('data' => '1')}
+    it { should contain_registry_value('UseWUServer').with('data' => '1')}
+    it { should contain_registry_value('RescheduleWaitTime').with('data' => '1')}
+    it { should contain_registry_value('NoAutoRebootWithLoggedOnUsers').with('data' => '1')}
+  end
+
+  $invalid_params.keys.each do |key, value|
+    context "passing invalid param to #{key}" do
+      let :params do
+        { :key => :value }
+      end
+      it { is_expected.to raise_error(Puppet::Error) }
+    end
+  end
+
+  context "Using deprecated params" do
+    let :params do
+      { :noAutoUpdate => '1', :aUOptions => '2', :scheduledInstallDay => '2',
+        :scheduledInstallTime => '2', :useWUServer => '1', :rescheduleWaitTime => '2',
+        :noAutoRebootWithLoggedOnUsers => '1' }
+    end
+    it { should contain_registry_value('NoAutoUpdate').with('data' => '1')}
+    it { should contain_registry_value('AUOptions').with('data' => '2')}
+    it { should contain_registry_value('ScheduledInstallDay').with('data' => '2')}
+    it { should contain_registry_value('ScheduledInstallTime').with('data' => '2')}
+    it { should contain_registry_value('UseWUServer').with('data' => '1')}
+    it { should contain_registry_value('RescheduleWaitTime').with('data' => '2')}
+    it { should contain_registry_value('NoAutoRebootWithLoggedOnUsers').with('data' => '1')}
+  end
+end

--- a/modules/services/windows/update/windows_update/spec/spec.opts
+++ b/modules/services/windows/update/windows_update/spec/spec.opts
@@ -1,0 +1,6 @@
+--format
+s
+--colour
+--loadby
+mtime
+--backtrace

--- a/modules/services/windows/update/windows_update/spec/spec_helper.rb
+++ b/modules/services/windows/update/windows_update/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/modules/services/windows/update/windows_update/spec/spec_helper_acceptance.rb
+++ b/modules/services/windows/update/windows_update/spec/spec_helper_acceptance.rb
@@ -1,0 +1,36 @@
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+
+
+hosts.each do |host|
+  
+  
+	version = ENV['PUPPET_GEM_VERSION']
+	install_puppet(:version => version)
+end
+
+Spec.configure do |c|
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+	c.formatter = :documentation
+
+	c.before :suite do
+		#The gets around a bug where windows can't validate the cert when using https
+		forge_repo = '--module_repository=http://forge.puppetlabs.com'
+
+		hosts.each do |host|
+			c.host = host
+      
+			
+
+			path = (File.expand_path(File.dirname(__FILE__)+'/../')).split('/')
+			name = path[path.length-1].split('-')[1]
+
+			copy_module_to(host, :source => proj_root, :module_name => name)
+
+      
+			on host, puppet('module','install', forge_repo, "puppetlabs-stdlib"), { :acceptable_exit_codes => [0,1] }
+	    
+	  end
+  end
+end

--- a/modules/services/windows/update/windows_update/windows_update.pp
+++ b/modules/services/windows/update/windows_update/windows_update.pp
@@ -1,0 +1,3 @@
+include windows_autoupdate
+
+class { 'windows_autoupdate': noAutoUpdate => '1' }

--- a/scenarios/simple_examples/clean_system_with_update_unix.xml
+++ b/scenarios/simple_examples/clean_system_with_update_unix.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<scenario xmlns="http://www.github/cliffe/SecGen/scenario"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.github/cliffe/SecGen/scenario">
+
+  <!-- an example remote storage system, with a remotely exploitable vulnerability that can then be escalated to root -->
+  <system>
+    <system_name>clean_system_with_update</system_name>
+    <base platform="linux"/>
+
+    <service module_path="modules/services/unix/update/unix_update"></service>
+
+    <!--<network type="private_network" range="dhcp"></network>-->
+  </system>
+
+</scenario>


### PR DESCRIPTION
Should make sure that newest software can be gotten off of the systems repositories. Also should be machine independent other then selecting whether windows or unix. Commands in the unix_update module need to be modified for different systems to be absolute paths. Added windows services directory and included a puppetforge module to control auto-updates within windows (currently disables auto-updates for windows systems).

Changes:
Added puppetforge windows module https://forge.puppet.com/puppet/windows_autoupdate/readme.
Added Debian repository updater.
Added secgen_metadata for both modules (unix_update and windows_update)
Added custom scenario clean_system_with_update_unix.xml which creates a clean system with just the update (can be used for testing)