### PR TITLE
Apache v2 licence for vulnerabilities

### DIFF
--- a/lib/schemas/vulnerability_metadata_schema.xsd
+++ b/lib/schemas/vulnerability_metadata_schema.xsd
@@ -68,6 +68,7 @@
           <xs:simpleType>
             <xs:restriction base="xs:string">
               <xs:enumeration value="MIT"/>
+              <xs:enumeration value="Apache v2"/>
             </xs:restriction>
           </xs:simpleType>
         </xs:element>


### PR DESCRIPTION
Add the Apache v2 licence to the vulnerabilities schema.