### PR TITLE
Module loader bug fix

### DIFF
--- a/secgen.rb
+++ b/secgen.rb
@@ -52,7 +52,7 @@ def build_config(scenario, out_dir)
 
   Print.info 'Reading available network modules...'
   all_available_networks = ModuleReader.read_networks
-  Print.std "#{all_available_services.size} network modules loaded"
+  Print.std "#{all_available_networks.size} network modules loaded"
 
   Print.info 'Resolving systems: randomising scenario...'
   # for each system, select modules


### PR DESCRIPTION
Changes output of build_config to output correct information about networks, was previously displaying all_available_services count instead of all_available_networks