### PR TITLE
Vulnerability: MoinMoin-1.9.5 wiki

### DIFF
--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/files/apache2.conf
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/files/apache2.conf
@@ -1,0 +1,286 @@
+# This is the main Apache server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See http://httpd.apache.org/docs/2.2/ for detailed information about
+# the directives and /usr/share/doc/apache2-common/README.Debian.gz about
+# Debian specific hints.
+#
+#
+# Summary of how the Apache 2 configuration works in Debian:
+# The Apache 2 web server configuration in Debian is quite different to
+# upstream's suggested way to configure the web server. This is because Debian's
+# default Apache2 installation attempts to make adding and removing modules,
+# virtual hosts, and extra configuration directives as flexible as possible, in
+# order to make automating the changes and administering the server as easy as
+# possible.
+
+# It is split into several files forming the configuration hierarchy outlined
+# below, all located in the /etc/apache2/ directory:
+#
+#	/etc/apache2/
+#	|-- apache2.conf
+#	|	`--  ports.conf
+#	|-- mods-enabled
+#	|	|-- *.load
+#	|	`-- *.conf
+#	|-- conf.d
+#	|	`-- *
+# 	`-- sites-enabled
+#	 	`-- *
+#
+#
+# * apache2.conf is the main configuration file (this file). It puts the pieces
+#   together by including all remaining configuration files when starting up the
+#   web server.
+#
+#   In order to avoid conflicts with backup files, the Include directive is
+#   adapted to ignore files that:
+#   - do not begin with a letter or number
+#   - contain a character that is neither letter nor number nor _-:.
+#   - contain .dpkg
+#
+#   Yet we strongly suggest that all configuration files either end with a
+#   .conf or .load suffix in the file name. The next Debian release will
+#   ignore files not ending with .conf (or .load for mods-enabled).
+#
+# * ports.conf is always included from the main configuration file. It is
+#   supposed to determine listening ports for incoming connections, and which
+#   of these ports are used for name based virtual hosts.
+#
+# * Configuration files in the mods-enabled/ and sites-enabled/ directories
+#   contain particular configuration snippets which manage modules or virtual
+#   host configurations, respectively.
+#
+#   They are activated by symlinking available configuration files from their
+#   respective *-available/ counterparts. These should be managed by using our
+#   helpers a2enmod/a2dismod, a2ensite/a2dissite. See
+#   their respective man pages for detailed information.
+#
+# * Configuration files in the conf.d directory are either provided by other
+#   packages or may be added by the local administrator. Local additions
+#   should start with local- or end with .local.conf to avoid name clashes. All
+#   files in conf.d are considered (excluding the exceptions noted above) by
+#   the Apache 2 web server.
+#
+# * The binary is called apache2. Due to the use of environment variables, in
+#   the default configuration, apache2 needs to be started/stopped with
+#   /etc/init.d/apache2 or apache2ctl. Calling /usr/bin/apache2 directly will not
+#   work with the default configuration.
+
+
+# Global configuration
+#
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# NOTE!  If you intend to place this on an NFS (or otherwise network)
+# mounted filesystem then please read the LockFile documentation (available
+# at <URL:http://httpd.apache.org/docs/2.2/mod/mpm_common.html#lockfile>);
+# you will save yourself a lot of trouble.
+#
+# Do NOT add a slash at the end of the directory path.
+#
+#ServerRoot "/etc/apache2"
+
+#
+# The accept serialization lock file MUST BE STORED ON A LOCAL DISK.
+#
+LockFile ${APACHE_LOCK_DIR}/accept.lock
+
+#
+# PidFile: The file in which the server should record its process
+# identification number when it starts.
+# This needs to be set in /etc/apache2/envvars
+#
+PidFile ${APACHE_PID_FILE}
+
+#
+# Timeout: The number of seconds before receives and sends time out.
+#
+Timeout 300
+
+#
+# KeepAlive: Whether or not to allow persistent connections (more than
+# one request per connection). Set to "Off" to deactivate.
+#
+KeepAlive On
+
+#
+# MaxKeepAliveRequests: The maximum number of requests to allow
+# during a persistent connection. Set to 0 to allow an unlimited amount.
+# We recommend you leave this number high, for maximum performance.
+#
+MaxKeepAliveRequests 100
+
+#
+# KeepAliveTimeout: Number of seconds to wait for the next request from the
+# same client on the same connection.
+#
+KeepAliveTimeout 5
+
+##
+## Server-Pool Size Regulation (MPM specific)
+## 
+
+# prefork MPM
+# StartServers: number of server processes to start
+# MinSpareServers: minimum number of server processes which are kept spare
+# MaxSpareServers: maximum number of server processes which are kept spare
+# MaxClients: maximum number of server processes allowed to start
+# MaxRequestsPerChild: maximum number of requests a server process serves
+<IfModule mpm_prefork_module>
+    StartServers          5
+    MinSpareServers       5
+    MaxSpareServers      10
+    MaxClients          150
+    MaxRequestsPerChild   0
+</IfModule>
+
+# worker MPM
+# StartServers: initial number of server processes to start
+# MinSpareThreads: minimum number of worker threads which are kept spare
+# MaxSpareThreads: maximum number of worker threads which are kept spare
+# ThreadLimit: ThreadsPerChild can be changed to this maximum value during a
+#              graceful restart. ThreadLimit can only be changed by stopping
+#              and starting Apache.
+# ThreadsPerChild: constant number of worker threads in each server process
+# MaxClients: maximum number of simultaneous client connections
+# MaxRequestsPerChild: maximum number of requests a server process serves
+<IfModule mpm_worker_module>
+    StartServers          2
+    MinSpareThreads      25
+    MaxSpareThreads      75 
+    ThreadLimit          64
+    ThreadsPerChild      25
+    MaxClients          150
+    MaxRequestsPerChild   0
+</IfModule>
+
+# event MPM
+# StartServers: initial number of server processes to start
+# MinSpareThreads: minimum number of worker threads which are kept spare
+# MaxSpareThreads: maximum number of worker threads which are kept spare
+# ThreadsPerChild: constant number of worker threads in each server process
+# MaxClients: maximum number of simultaneous client connections
+# MaxRequestsPerChild: maximum number of requests a server process serves
+<IfModule mpm_event_module>
+    StartServers          2
+    MinSpareThreads      25
+    MaxSpareThreads      75 
+    ThreadLimit          64
+    ThreadsPerChild      25
+    MaxClients          150
+    MaxRequestsPerChild   0
+</IfModule>
+
+# These need to be set in /etc/apache2/envvars
+User ${APACHE_RUN_USER}
+Group ${APACHE_RUN_GROUP}
+
+#
+# AccessFileName: The name of the file to look for in each directory
+# for additional configuration directives.  See also the AllowOverride
+# directive.
+#
+
+AccessFileName .htaccess
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being 
+# viewed by Web clients. 
+#
+<Files ~ "^\.ht">
+    Order allow,deny
+    Deny from all
+    Satisfy all
+</Files>
+
+#
+# DefaultType is the default MIME type the server will use for a document
+# if it cannot otherwise determine one, such as from filename extensions.
+# If your server contains mostly text or HTML documents, "text/plain" is
+# a good value.  If most of your content is binary, such as applications
+# or images, you may want to use "application/octet-stream" instead to
+# keep browsers from trying to display binary files as though they are
+# text.
+#
+# It is also possible to omit any default MIME type and let the
+# client's browser guess an appropriate action instead. Typically the
+# browser will decide based on the file's extension then. In cases
+# where no good assumption can be made, letting the default MIME type
+# unset is suggested  instead of forcing the browser to accept
+# incorrect  metadata.
+#
+DefaultType None
+
+
+#
+# HostnameLookups: Log the names of clients or just their IP addresses
+# e.g., www.apache.org (on) or 204.62.129.132 (off).
+# The default is off because it'd be overall better for the net if people
+# had to knowingly turn this feature on, since enabling it means that
+# each client request will result in AT LEAST one lookup request to the
+# nameserver.
+#
+HostnameLookups Off
+
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog ${APACHE_LOG_DIR}/error.log
+
+#
+# LogLevel: Control the number of messages logged to the error_log.
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+#
+LogLevel warn
+
+# Include module configuration:
+Include mods-enabled/*.load
+Include mods-enabled/*.conf
+
+# Include list of ports to listen on and which to use for name based vhosts
+Include ports.conf
+
+#
+# The following directives define some format nicknames for use with
+# a CustomLog directive (see below).
+# If you are behind a reverse proxy, you might want to change %h into %{X-Forwarded-For}i
+#
+LogFormat "%v:%p %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+LogFormat "%h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %O" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+
+# Include of directories ignores editors' and dpkg's backup files,
+# see the comments above for details.
+
+# Include generic snippets of statements
+Include conf.d/
+
+# Include the virtual host configurations:
+Include sites-enabled/
+
+#
+#  MoinMoin WSGI configuration
+#
+# you will invoke your moin wiki at the root url, like http://servername/FrontPage:
+WSGIScriptAlias /   /usr/local/share/moin/moin.wsgi
+
+# create some wsgi daemons - use these parameters for a simple setup
+WSGIDaemonProcess moin user=www-data group=www-data processes=5 threads=10 maximum-requests=1000 umask=0007
+
+# use the daemons we defined above to process requests!
+WSGIProcessGroup moin
+
+<Directory "/usr/local/share/moin">
+    Options All
+    AllowOverride All
+    Allow from all
+</Directory>

--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/files/moin.wsgi
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/files/moin.wsgi
@@ -1,0 +1,50 @@
+# -*- coding: iso-8859-1 -*-
+"""
+    MoinMoin - mod_wsgi driver script
+
+    To use this, add those statements to your Apache's VirtualHost definition:
+    
+    # you will invoke your moin wiki at the root url, like http://servername/FrontPage:
+    WSGIScriptAlias / /some/path/moin.wsgi
+
+    # create some wsgi daemons - use someuser.somegroup same as your data_dir:
+    WSGIDaemonProcess daemonname user=someuser group=somegroup processes=5 threads=10 maximum-requests=1000 umask=0007
+
+    # use the daemons we defined above to process requests!
+    WSGIProcessGroup daemonname
+
+    @copyright: 2008 by MoinMoin:ThomasWaldmann
+    @license: GNU GPL, see COPYING for details.
+"""
+
+import sys, os
+
+# a) Configuration of Python's code search path
+#    If you already have set up the PYTHONPATH environment variable for the
+#    stuff you see below, you don't need to do a1) and a2).
+
+# a1) Path of the directory where the MoinMoin code package is located.
+#     Needed if you installed with --prefix=PREFIX or you didn't use setup.py.
+#sys.path.insert(0, 'PREFIX/lib/python2.3/site-packages')
+
+# a2) Path of the directory where wikiconfig.py / farmconfig.py is located.
+#     See wiki/config/... for some sample config files.
+#sys.path.insert(0, '/path/to/wikiconfigdir')
+#sys.path.insert(0, '/path/to/farmconfigdir')
+sys.path.insert(0, '/usr/local/share/moin')
+
+# b) Configuration of moin's logging
+#    If you have set up MOINLOGGINGCONF environment variable, you don't need this!
+#    You also don't need this if you are happy with the builtin defaults.
+#    See wiki/config/logging/... for some sample config files.
+#from MoinMoin import log
+#log.load_config('/path/to/logging_configuration_file')
+
+from MoinMoin.web.serving import make_application
+
+# Creating the WSGI application
+# use shared=True to have moin serve the builtin static docs
+# use shared=False to not have moin serve static docs
+# use shared='/my/path/to/htdocs' to serve static docs from that path
+application = make_application(shared=True)
+

--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/manifests/config.pp
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/manifests/config.pp
@@ -1,0 +1,27 @@
+class moinmoin_195::config {
+
+  # Config files
+  file { '/usr/local/share/moin/moin.wsgi':
+    ensure => file,
+    source => 'puppet:///modules/moinmoin_195/moin.wsgi'
+  }
+
+  file { '/usr/local/share/moin/wikiconfig.py':
+    ensure => file,
+    source => '/usr/local/share/moin/config/wikiconfig.py'
+  }
+
+  # Web server config
+  file { '/etc/apache2/apache2.conf':
+    ensure => file,
+    source => 'puppet:///modules/moinmoin_195/apache2.conf'
+  }
+
+  # File permissions + ownership
+  exec { 'permissions-moinmoin':
+    command => '/bin/chown -R www-data:www-data /usr/local/share/moin;
+    /bin/chmod -R ug+rwx /usr/local/share/moin;
+    /bin/chmod -R o-rwx /usr/local/share/moin',
+    notify => Service['apache2']
+  }
+}

--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/manifests/install.pp
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/manifests/install.pp
@@ -1,10 +1,5 @@
 class moinmoin_195::install {
 
-  # Install dependencies
-  package { ['apache2' ,'libapache2-mod-wsgi']:
-    ensure => installed,
-  }
-
   # Require tarball
   file { '/usr/local/src/MoinMoin-1.9.5.tar.gz':
     ensure => file,
@@ -22,6 +17,11 @@ class moinmoin_195::install {
   exec { 'install-moinmoin':
     command => '/usr/bin/python setup.py install --force --prefix=/usr/local --record=install.log',
     cwd => '/usr/local/src/moin-1.9.5',
+  }
+
+  # Apache wsgi plugin
+  package { 'libapache2-mod-wsgi':
+    ensure => installed,
   }
 
   # Cleanup step

--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/manifests/install.pp
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/manifests/install.pp
@@ -23,4 +23,9 @@ class moinmoin_195::install {
     command => '/usr/bin/python setup.py install --force --prefix=/usr/local --record=install.log',
     cwd => '/usr/local/src/moin-1.9.5',
   }
+
+  # Cleanup step
+  exec { 'cleanup':
+    command => '/bin/rm /usr/local/src/* -rf',
+  }
 }

--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/manifests/install.pp
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/manifests/install.pp
@@ -1,0 +1,26 @@
+class moinmoin_195::install {
+
+  # Install dependencies
+  package { ['apache2' ,'libapache2-mod-wsgi']:
+    ensure => installed,
+  }
+
+  # Require tarball
+  file { '/usr/local/src/MoinMoin-1.9.5.tar.gz':
+    ensure => file,
+    source => 'puppet:///modules/moinmoin_195/MoinMoin-1.9.5.tar.gz',
+  }
+
+  # Unpack tar
+  exec { 'unzip-moinmoin':
+    command     => '/bin/tar -xzf /usr/local/src/MoinMoin-1.9.5.tar.gz',
+    cwd         => '/usr/local/src',
+    creates     => '/usr/local/src/moin-1.9.5/',
+  }
+
+  # Install moinmoin
+  exec { 'install-moinmoin':
+    command => '/usr/bin/python setup.py install --force --prefix=/usr/local --record=install.log',
+    cwd => '/usr/local/src/moin-1.9.5',
+  }
+}

--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/manifests/service.pp
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/manifests/service.pp
@@ -1,0 +1,7 @@
+class moinmoin_195::service {
+  service { 'apache2':
+    ensure  => running,
+    enable  => true,
+    require => Exec['permissions-moinmoin'],
+  }
+}

--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/moinmoin_195.pp
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/moinmoin_195.pp
@@ -1,0 +1,3 @@
+include moinmoin_195::install
+include moinmoin_195::config
+include moinmoin_195::service

--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/secgen_metadata.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<vulnerability xmlns="http://www.github/cliffe/SecGen/vulnerability"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.github/cliffe/SecGen/vulnerability">
+
+  <name>MoinMoin v1.9.5</name>
+  <author>Thomas Shaw</author>
+  <module_license>MIT</module_license>
+  <description>
+    Moin v1.9.5 released in December 2012 contains multiple vulnerabilities.
+    Remote code execution possible in MoinMoin v1.9.5 twikidraw and anywikidraw modules.
+    Path traversal found in AttachFile.
+  </description>
+
+  <type>webapp</type>
+  <privilege>user</privilege>
+  <access>remote</access>
+  <platform>linux</platform>
+
+  <!--optional vulnerability details-->
+  <difficulty>medium</difficulty>
+  <cve>CVE-2012-6080</cve>
+  <cve>CVE-2012-6081</cve>
+
+  <cvss_base_score>6</cvss_base_score>
+  <cvss_vector>AV:N/AC:M/Au:S/C:P/I:P/A:P</cvss_vector>
+  <reference>https://moinmo.in/SecurityFixes</reference>
+  <reference>http://hg.moinmo.in/moin/1.9/rev/7e7e1cbb9d3f</reference>
+  <reference>https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-6081</reference>
+  <software_name>moinmoin</software_name>
+  <software_license>GPL</software_license>
+
+  <!--optional hints-->
+  <msf_module>exploit/unix/webapp/moinmoin_twikidraw</msf_module>
+  <solution>
+    Remote code execution possible in twikidraw and anywikidraw modules.
+    Path traversal found in AttachFile module.
+  </solution>
+
+  <!--Conflicts with apache modules-->
+  <conflict>
+    <software_name>apache</software_name>
+  </conflict>
+
+</vulnerability>

--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/secgen_metadata.xml
@@ -37,6 +37,10 @@
     Path traversal found in AttachFile module.
   </solution>
 
+  <conflict>
+    <type>webapp</type>
+  </conflict>
+
   <!--TODO: Depends on apache module-->
   <!--<dependency>-->
     <!--<module>apache</module>-->

--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/secgen_metadata.xml
@@ -37,9 +37,9 @@
     Path traversal found in AttachFile module.
   </solution>
 
-  <!--Conflicts with apache modules-->
-  <conflict>
-    <software_name>apache</software_name>
-  </conflict>
+  <!--TODO: Depends on apache module-->
+  <!--<dependency>-->
+    <!--<module>apache</module>-->
+  <!--</dependency>-->
 
 </vulnerability>

--- a/scenarios/simple_examples/moinmoin_195_vulnerabilitiy.xml
+++ b/scenarios/simple_examples/moinmoin_195_vulnerabilitiy.xml
@@ -8,6 +8,11 @@
     <system_name>file_server</system_name>
     <base platform="linux"/>
 
+    <!--TODO: Dependency-->
+    <service module_path="modules/services/unix/update/unix_update"></service>
+    <service module_path="modules/services/unix/http/apache"></service>
+    <!--TODO: /Dependency-->
+
     <vulnerability module_path=".*moinmoin_195"/>
 
     <network type="private_network" range="dhcp"/>

--- a/scenarios/simple_examples/moinmoin_195_vulnerabilitiy.xml
+++ b/scenarios/simple_examples/moinmoin_195_vulnerabilitiy.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<scenario xmlns="http://www.github/cliffe/SecGen/scenario"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.github/cliffe/SecGen/scenario">
+
+  <system>
+    <system_name>file_server</system_name>
+    <base platform="linux"/>
+
+    <vulnerability module_path=".*moinmoin_195"/>
+
+    <network type="private_network" range="dhcp"/>
+  </system>
+
+</scenario>


### PR DESCRIPTION
New vulnerability: MoinMoin-1.9.5

This modules provides a wiki that depends upon an apache2 installation. I've included a conflict for  \<software_name>apache </..> to prevent multiple versions of apache installing with moinmoin. 

I would like some input if anyone has suggestions on the correct way of handling situations like this. I considered including the service apache2 module as a dependency + using that module instead of just installing the apache2 package from the package-manager with puppet.


Exploitation evidence (using msfconsole exploit/unix/webapp/moin):
![image](https://cloud.githubusercontent.com/assets/3964474/17093550/d945359e-5241-11e6-9852-9b780cf8644f.png)

Cheers!