### PR TITLE
Module dependencies

### DIFF
--- a/lib/helpers/constants.rb
+++ b/lib/helpers/constants.rb
@@ -1,4 +1,4 @@
-## FILE_CONSTANTS ##
+## FILE CONSTANTS ##
 
 # Root directory of SecGen file structure
 ROOT_DIR = File.expand_path('../../../',__FILE__)
@@ -20,7 +20,7 @@ PROJECTS_DIR = "#{ROOT_DIR}/projects"
 ENVIRONMENTS_PATH = "#{ROOT_DIR}/modules/build/environments"
 
 
-## PATH_CONSTANTS ##
+## PATH CONSTANTS ##
 
 # Path to modules directories
 MODULES_PATH = "#{ROOT_DIR}/modules/"
@@ -33,7 +33,7 @@ BASES_PATH = "#{MODULES_PATH}bases/"
 DOCUMENTATION_PATH = "#{ROOT_DIR}/documentation/yard/doc"
 
 
-## VAGRANT_FILE_CONSTANTS ##
+## VAGRANT FILE CONSTANTS ##
 
 # Path to cleanup directory
 PATH_TO_CLEANUP = "#{ROOT_DIR}/modules/build/puppet/"
@@ -43,7 +43,10 @@ VAGRANT_TEMPLATE_FILE = "#{ROOT_DIR}/lib/templates/Vagrantfile.erb"
 
 PUPPET_TEMPLATE_FILE = "#{ROOT_DIR}/lib/templates/Puppetfile.erb"
 
-## VERSION_CONSTANTS ##
+## INTEGER CONSTANTS ##
+RETRIES_LIMIT = 10
+
+## VERSION CONSTANTS ##
 
 # Version number of SecGen
 # e.g. [release state (0 = alpha, 3 = final release)].[Major bug fix].[Minor bug fix].[Cosmetic or other features]

--- a/lib/objects/module.rb
+++ b/lib/objects/module.rb
@@ -6,10 +6,11 @@ class Module
   attr_accessor :module_type # vulnerability|service
   attr_accessor :attributes  # attributes are hashes that contain arrays of values
   # Each attribute is stored in a hash containing an array of values (because elements such as author can repeat).
-  # For module *selectors*, filters are stored directly in the attributes hash rather than as an array of values.
+  # Module *selectors*, store filters in the attributes hash.
   # XML validity ensures valid and complete information.
 
   attr_accessor :conflicts
+  attr_accessor :requires
   attr_accessor :puppet_file
   attr_accessor :puppet_other_path
 
@@ -17,8 +18,9 @@ class Module
   def initialize(module_type)
     self.module_type = module_type
     self.conflicts = []
+    self.requires = []
     self.attributes = {}
-    self.attributes[:module_type] = module_type # add as an attribute for filtering
+    # self.attributes['module_type'] = module_type # add as an attribute for filtering
   end
 
   # @return [Object] a string for console output
@@ -27,6 +29,7 @@ class Module
     #{module_type}: #{module_path}
       attributes: #{attributes.inspect}
       conflicts: #{conflicts.inspect}
+      requires: #{requires.inspect}
       puppet file: #{puppet_file}
       puppet path: #{puppet_other_path}
     END
@@ -38,6 +41,7 @@ class Module
     # #{module_type}: #{module_path}
     #   attributes: #{attributes.inspect}
     #   conflicts: #{conflicts.inspect}
+    #   requires: #{requires.inspect}
     END
   end
 
@@ -76,14 +80,55 @@ class Module
   def conflicts_with(other_module)
     # for each conflict
     self.conflicts.each do |conflict|
-      all_conflict_conditions_met = true
-      # for each conflict hash key for a single conflict
-      conflict.keys.each do |conflict_key|
-        key_matched = false
-        # all_conflict_conditions_met = true
-        # does that conflict with selected modules?
+      if other_module.matches_attributes_requirement(conflict)
+        return true
+      end
+    end
+    false
+  end
 
-        if other_module.attributes["#{conflict_key}"] != nil
+  def matches_attributes_requirement(required)
+    all_conditions_met = true
+    required.keys.each do |require_key|
+      key_matched = false
+
+      if self.attributes["#{require_key}"] != nil
+        # for each corresponding value in the previously selected module
+        self.attributes["#{require_key}"].each do |value|
+          # for each value in the required list
+          required["#{require_key}"].each do |required_value|
+            if Regexp.new(required_value).match(value)
+              key_matched = true
+            end
+          end
+        end
+      end
+      # any failure to match
+      unless key_matched
+        return false
+      end
+    end
+    all_conditions_met
+  end
+
+  def printable_name
+    "#{self.attributes['name'][0]} (#{self.module_path})"
+  end
+
+
+
+  def select_required_modules(available_modules, selected_modules)
+    modules_to_add = []
+    available_modules_rnd = available_modules.clone.shuffle!
+
+
+    available_modules_rnd.each do |possible_module_selection|
+
+      # for each requirement
+      self.requires.each do |requires|
+        # if possible_module_selection.
+
+        if possible_module_selection.attributes["#{conflict_key}"] != nil
           # for each corresponding value in the previously selected module
           other_module.attributes["#{conflict_key}"].each do |value|
             # for each value in the conflict list
@@ -94,16 +139,42 @@ class Module
             end
           end
         end
-        # any failure to match a conflict
-        unless key_matched
-          all_conflict_conditions_met = false
-        end
-      end
-      if all_conflict_conditions_met
-        return true
+
       end
     end
-    false
+
+    modules_to_add
+  end
+
+
+
+  def select_required_modules(available_modules, selected_modules)
+    modules_to_add = []
+    available_modules_rnd = available_modules.clone.shuffle!
+
+
+    available_modules_rnd.each do |possible_module_selection|
+
+      # for each requirement
+      self.requires.each do |requires|
+        # if possible_module_selection.
+
+        if possible_module_selection.attributes["#{conflict_key}"] != nil
+          # for each corresponding value in the previously selected module
+          other_module.attributes["#{conflict_key}"].each do |value|
+            # for each value in the conflict list
+            conflict["#{conflict_key}"].each do |conflict_value|
+              if Regexp.new(conflict_value).match(value)
+                key_matched = true
+              end
+            end
+          end
+        end
+
+      end
+    end
+
+    modules_to_add
   end
 
 end

--- a/lib/readers/module_reader.rb
+++ b/lib/readers/module_reader.rb
@@ -107,7 +107,15 @@ class ModuleReader
           (conflict[node.name] ||= []).push(node.content)
         }
         new_module.conflicts.push(conflict)
+      end
 
+      # for each dependency in the module
+      doc.xpath("/#{module_type}/requires").each do |requires_doc|
+        require = {}
+        requires_doc.elements.each {|node|
+          (require[node.name] ||= []).push(node.content)
+        }
+        new_module.requires.push(require)
       end
 
       modules.push(new_module)

--- a/lib/readers/system_reader.rb
+++ b/lib/readers/system_reader.rb
@@ -51,9 +51,10 @@ class SystemReader
 
       # for each module selection
       system_node.xpath('vulnerability | service | network | base').each do |module_node|
-        module_selector = Module.new("#{module_node.name}_selecter")
+        # create a selector module, which is a regular module instance used as a placeholder for matching requirements
+        module_selector = Module.new(module_node.name)
         module_node.xpath('@*').each do |attr|
-          module_selector.attributes["#{attr.name}"] = attr.text unless attr.text.nil? || attr.text == ''
+          module_selector.attributes["#{attr.name}"] = [attr.text] unless attr.text.nil? || attr.text == ''
         end
         Print.verbose " #{module_node.name}, selecting based on:"
         module_selector.attributes.each do |attr|

--- a/lib/schemas/base_metadata_schema.xsd
+++ b/lib/schemas/base_metadata_schema.xsd
@@ -51,7 +51,6 @@
           <xs:complexType>
             <xs:sequence>
               <xs:element name="module_path" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-              <!--required SecGen module details-->
               <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
               <xs:element name="author" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
               <xs:element name="module_license" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
@@ -68,6 +67,29 @@
             </xs:sequence>
           </xs:complexType>
         </xs:element>
+        <!-- must co-exist with a system matching ALL of the optionally specified values (can be repeated for OR)-->
+        <!-- if a scenario does not include one already, the first match (randomly) found will be added-->
+        <xs:element name="requires" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="module_path" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="author" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="module_license" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="platform" type="platformOptions" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="distro" type="platformOptions" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="url" type="platformOptions" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="vagrantbase" type="platformOptions" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="software_license" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/lib/schemas/service_metadata_schema.xsd
+++ b/lib/schemas/service_metadata_schema.xsd
@@ -40,7 +40,7 @@
         <xs:element name="conflict" minOccurs="0" maxOccurs="unbounded">
           <xs:complexType>
             <xs:sequence>
-              <!--required SecGen module details-->
+              <xs:element name="module_path" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
               <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
               <xs:element name="author" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
               <xs:element name="module_license" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
@@ -55,6 +55,28 @@
             </xs:sequence>
           </xs:complexType>
         </xs:element>
+
+        <!-- must co-exist with a system matching ALL of the optionally specified values (can be repeated for OR)-->
+        <!-- if a scenario does not include one already, the first match (randomly) found will be added before this module-->
+        <xs:element name="requires" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="module_path" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="author" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="module_license" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="platform" type="platformOptions" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="software_name" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="software_license" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/lib/schemas/vulnerability_metadata_schema.xsd
+++ b/lib/schemas/vulnerability_metadata_schema.xsd
@@ -129,6 +129,40 @@
           </xs:complexType>
         </xs:element>
 
+        <!-- must co-exist with a system matching ALL of the optionally specified values (can be repeated for OR)-->
+        <!-- if a scenario does not include one already, the first match (randomly) found will be added before this module-->
+        <xs:element name="requires" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="module_path" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="author" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="module_license" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="type" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="privilege" type="privlegeOptions" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="access" type="accessOptions" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="platform" type="platformOptions" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="difficulty" type="difficultyOptions" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="cve" type="CVEregexp" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="cvss_base_score" type="oneDecimalPlace" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="cvss_vector" type="CVSSregexp" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="software_name" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="software_license" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="breadcrumb" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+
+              <xs:element name="msf_module" type="MSFregexp" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="hint" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+              <xs:element name="solution" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/modules/services/unix/http/apache/secgen_metadata.xml
+++ b/modules/services/unix/http/apache/secgen_metadata.xml
@@ -20,5 +20,15 @@
   <conflict>
     <software_name>apache</software_name>
   </conflict>
+  <requires>
+    <type>update</type>
+  </requires>
+  <!-- for testing purposes -->
+  <!--<requires>-->
+    <!--<type>THIS DOES NOT EXIST</type>-->
+  <!--</requires>-->
+  <!--<requires>-->
+    <!--<type>ftp</type>-->
+  <!--</requires>-->
 
 </service>

--- a/modules/services/unix/http/apache/secgen_metadata.xml
+++ b/modules/services/unix/http/apache/secgen_metadata.xml
@@ -23,12 +23,4 @@
   <requires>
     <type>update</type>
   </requires>
-  <!-- for testing purposes -->
-  <!--<requires>-->
-    <!--<type>THIS DOES NOT EXIST</type>-->
-  <!--</requires>-->
-  <!--<requires>-->
-    <!--<type>ftp</type>-->
-  <!--</requires>-->
-
 </service>

--- a/modules/services/unix/update/unix_update/secgen_metadata.xml
+++ b/modules/services/unix/update/unix_update/secgen_metadata.xml
@@ -3,7 +3,7 @@
 <service xmlns="http://www.github/cliffe/SecGen/service"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.github/cliffe/SecGen/service">
-  <name>Unix_update_service</name>
+  <name>Unix update repository</name>
   <author>Jason Keighley</author>
   <module_license>Apache v2</module_license>
   <description>An update module for unix</description>
@@ -11,13 +11,9 @@
   <type>update</type>
   <platform>linux</platform>
 
-  <!--optional details-->
-  <software_name>unix_update</software_name>
-  <software_license>Apache v2</software_license>
-
-  <!--Cannot co-exist with other apache installations-->
+  <!--Cannot co-exist with Windows-->
   <conflict>
-    <software_name>windows_update</software_name>
+    <module_path>modules/[^/]*/windows/.*</module_path>
   </conflict>
 
 </service>

--- a/modules/services/windows/update/windows_update/secgen_metadata.xml
+++ b/modules/services/windows/update/windows_update/secgen_metadata.xml
@@ -3,7 +3,7 @@
 <service xmlns="http://www.github/cliffe/SecGen/service"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.github/cliffe/SecGen/service">
-  <name>Windows_automatic_update_control_service</name>
+  <name>Windows Automatic Update Control Service</name>
   <author>Liam Bennett</author>
   <module_license>MIT</module_license>
   <description>An update module for windows</description>
@@ -16,9 +16,9 @@
   <software_name>windows_update</software_name>
   <software_license>MIT</software_license>
 
-  <!--Cannot co-exist with other apache installations-->
+  <!--Cannot co-exist with linux installations-->
   <conflict>
-    <software_name>unix_update</software_name>
+    <module_path>modules/[^/]*/(unix|linux)/.*</module_path>
   </conflict>
 
 </service>

--- a/modules/vulnerabilities/unix/local/writeable_shadow/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/local/writeable_shadow/secgen_metadata.xml
@@ -28,14 +28,4 @@
     <author>Lewis Ardern</author>
   </conflict>
 
-  <!-- for testing purposes, likely to trigger an unresolveable conflict with the default scenario (sometimes) -->
-  <!--<conflict>-->
-    <!--<type>ftp</type>-->
-  <!--</conflict>-->
-  <!-- for testing purposes -->
-  <!--<requires>-->
-    <!--<type>httpd</type>-->
-    <!--<software_name>apache</software_name>-->
-  <!--</requires>-->
-
 </vulnerability>

--- a/modules/vulnerabilities/unix/local/writeable_shadow/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/local/writeable_shadow/secgen_metadata.xml
@@ -16,18 +16,10 @@
 
   <!--optional vulnerability details-->
   <difficulty>medium</difficulty>
-  <!--<cve></cve>-->
+
   <cvss_base_score>6.6</cvss_base_score>
   <cvss_vector>AV:L/AC:M/Au:S/C:C/I:C/A:C</cvss_vector>
-  <reference></reference>
-  <software_name>nfsd</software_name>
-  <software_license>GPLv2</software_license>
 
-  <!--optional breadcrumb (info that is leaked and required to exploit)-->
-  <!--<breadcrumb></breadcrumb>-->
-
-  <!--optional hints-->
-  <!--<msf_module></msf_module>-->
   <hint>An access control misconfiguration</hint>
   <solution>Edit the shadow file to set a password for root</solution>
 
@@ -35,8 +27,15 @@
     <name>Writeable Shadow File</name>
     <author>Lewis Ardern</author>
   </conflict>
-  <conflict>
-    <type>ftp</type>
-  </conflict>
+
+  <!-- for testing purposes, likely to trigger an unresolveable conflict with the default scenario (sometimes) -->
+  <!--<conflict>-->
+    <!--<type>ftp</type>-->
+  <!--</conflict>-->
+  <!-- for testing purposes -->
+  <!--<requires>-->
+    <!--<type>httpd</type>-->
+    <!--<software_name>apache</software_name>-->
+  <!--</requires>-->
 
 </vulnerability>

--- a/scenarios/default_scenario.xml
+++ b/scenarios/default_scenario.xml
@@ -9,8 +9,6 @@
 		<system_name>storage_server</system_name>
 		<base platform="linux"/>
 
-		<!--<service type="httpd"/>-->
-
 		<vulnerability privilege="user" access="remote" />
 		<vulnerability privilege="root" access="local" />
 

--- a/scenarios/default_scenario.xml
+++ b/scenarios/default_scenario.xml
@@ -9,10 +9,11 @@
 		<system_name>storage_server</system_name>
 		<base platform="linux"/>
 
+		<!--<service type="httpd"/>-->
+
 		<vulnerability privilege="user" access="remote" />
 		<vulnerability privilege="root" access="local" />
 
-		<service type="httpd"/>
 		<service/>
 
 		<network type="private_network" range="dhcp"/>

--- a/secgen.rb
+++ b/secgen.rb
@@ -59,7 +59,7 @@ def build_config(scenario, out_dir)
   all_available_modules = all_available_bases + all_available_vulnerabilties + all_available_services + all_available_networks
   # update systems with module selections
   systems.map! {|system|
-    system.module_selections = system.resolve_module_selection(all_available_modules, 0)
+    system.module_selections = system.resolve_module_selection(all_available_modules)
     system
   }
 
@@ -68,7 +68,7 @@ def build_config(scenario, out_dir)
   creator = ProjectFilesCreator.new(systems, out_dir, scenario)
   creator.write_files
 
-  Print.info "Project files created."
+  Print.info 'Project files created.'
 end
 
 # Builds the vm via the vagrant file in the project dir
@@ -76,7 +76,7 @@ end
 def build_vms(project_dir)
   Print.info "Building project: #{project_dir}"
   GemExec.exe('vagrant', project_dir, 'up')
-  Print.info "VMs created."
+  Print.info 'VMs created.'
 end
 
 # Runs methods to run and configure a new vm from the configuration file


### PR DESCRIPTION
Any module can include in secgen_metadata.xml \<requires> tags to require other modules that satisfy a set of conditions are also in the scenario. When selecting a module, each dependency is resolved by checking if a module already satisfies the condition, in which case nothing happens, or a module that satisfies all the conditions is randomly selected and added to the scenario. This is recursive so a module can require modules that require modules. 

When conflicts occur (say for example, a previously selected module conflicts with all the valid options for resolving a dependency) the scenario is regenerated. This bruteforce approach is fairly effective, but \<conflict> tags should be avoided wherever possible because they add complexity and reduce randomisation possibilities.

A module can have multiple \<requires>, each of which will ensure a single module fulfills all of the conditions, which are regexp matches against attributes.

For example, for a module that needs to have a repo refresh (apt-get update) first:
````  
  <requires>
    <type>update</type>
  </requires>
````
Or for a module that requires apache be installed by another module (rather than the module itself installing apache, alternatively):
````
<requires>
    <type>httpd</type>
    <software_name>apache</software_name>
  </requires>
````

In this (silly) example, writable_shadow requires apache which requires update:
![recursive_dependencies](https://cloud.githubusercontent.com/assets/670192/17168086/4a08e162-53d8-11e6-83a0-0892d4fc2d68.png)

In another silly example, here apache requires ftp, but all ftp modules conflict with writable_shadow: 
![recursive_dependency_resolution](https://cloud.githubusercontent.com/assets/670192/17168883/b18ff362-53dc-11e6-8288-fa49a5f3459e.png)

Still TODO: treat base modules separately