### PR TITLE
Fix for the samba service module

### DIFF
--- a/modules/services/unix/file_share/samba/samba.pp
+++ b/modules/services/unix/file_share/samba/samba.pp
@@ -1,11 +1,1 @@
-class { 'samba':
-  require => Exec['update'],
-  puppi => true,
-  # monitor      => true,
-  # monitor_tool => [ 'nagios' , 'monit' , 'munin' ],
-  firewall      => true,
-  firewall_tool => 'iptables',
-  firewall_src  => '10.42.0.0/24',
-  firewall_dst  => $ipaddress_eth0,
-}
-
+class { 'samba': }


### PR DESCRIPTION
Merge of legacy code into Cliffe/master left module broken due to old Exec['update'] code.
Removed all legacy and non samba related code.
Only installs samba.
Tested and seems to be working.