### PR TITLE
Test module command.

### DIFF
--- a/lib/output/scenario_file_creator.rb
+++ b/lib/output/scenario_file_creator.rb
@@ -1,0 +1,38 @@
+class ScenarioFileCreator
+  def self.build_scenario(scenario_tmp_file, options)
+    scenario_tmp_file.path
+
+    puts options
+
+    ns = {
+            'xmlns' => "http://www.github/cliffe/SecGen/scenario",
+            'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
+            'xsi:schemaLocation' => "http://www.github/cliffe/SecGen/scenario"
+        }
+
+    builder = Nokogiri::XML::Builder.new do |xml|
+      xml.scenario (ns) {
+        xml.system {
+          xml.system_name "#{options[:module]}_test_system"
+          xml.base(:platform => options[:basebox_type])
+          case options[:module_type]
+            when 'vulnerability'
+              xml.vulnerability(:module_path => options[:module])
+            when 'service'
+              xml.service(:module_path => options[:module])
+            when 'utility'
+              xml.utility(:module_path => options[:module])
+            else
+              puts "Unexpected module type: #{options[:module_type]}"
+              exit
+          end
+          xml.network(:type => options[:network_type], :range => 'dhcp')
+        }
+      }
+    end
+
+    scenario_tmp_file.write(xml)
+
+    return scenario_tmp_file
+  end
+end

--- a/lib/output/scenario_file_creator.rb
+++ b/lib/output/scenario_file_creator.rb
@@ -31,7 +31,7 @@ class ScenarioFileCreator
       }
     end
 
-    scenario_tmp_file.write(xml)
+    scenario_tmp_file.write(builder.doc)
 
     return scenario_tmp_file
   end

--- a/secgen.rb
+++ b/secgen.rb
@@ -15,18 +15,42 @@ def usage
   Print.std "Usage:
    #{$0} [--options] <command>
 
-   OPTIONS:
+   MAIN OPTIONS:
    --scenario [xml file], -s [xml file]: set the scenario to use
               (defaults to #{SCENARIO_XML})
    --project [output dir], -p [output dir]: directory for the generated project
               (output will default to #{default_project_dir})
+
+   CREATE-SCENARIO OPTIONS:
    --help, -h: shows this usage information
+   --module [name]: sets module to use with create-scenario command
+   --module-type [type]: sets module type to use with create-scenario command
+               (type can be set to utility, service or vulnerability)
+   --network-type [type]: sets network type to use with create-scenario command
+               (type can be set to private-network)
+   --basebox-type [type]: sets basebox type to use with create-scenario command
+               (type can be set to linux, unix or windows
+
+   VIRTUAL MACHINE OPTIONS:
+   --gui-output', '-g': Spawns the virtual machine once created
+   --memory-per-vm [memory]: Sets the amount of RAM to be used each vm
+               (cannot be used with --total-memory option)
+   --total-memory [memory]: Sets the amount of RAM to be used for all vms
+               (cannot be used with --memory-per-vm)
+   --max-cpu-cores [core count]: Sets the max amount of cpu cores to be used for the vms
+               (defaults to max cores if value higher then max system cores given)
+   --max-cpu-usage [max usage]: Sets the maximum cpu usage percentage for all the vms
+               (should be given a value of 1-100)
+
 
    COMMANDS:
    run, r: builds project and then builds the VMs
    build-project, p: builds project (vagrant and puppet config), but does not build VMs
    build-vms [/project/dir], v [project #]: builds VMs from a previously generated project
               (use in combination with --project [dir])
+   create-scenario: builds a scenario from given command line options
+              (requires the --module [name] and --module-type [type] options to function)
+              (can also be given options --basebox-type and --network-type)
 "
   exit
 end
@@ -158,9 +182,6 @@ opts = GetoptLong.new(
   [ '--module-type', GetoptLong::REQUIRED_ARGUMENT],
   [ '--basebox-type', GetoptLong::REQUIRED_ARGUMENT],
   [ '--network-type', GetoptLong::REQUIRED_ARGUMENT],
-  #########################################################
-  # [ '--number-of-systems', GetoptLong::REQUIRED_ARGUMENT],
-  # [ '--', GetoptLong::REQUIRED_ARGUMENT],
 )
 
 scenario = SCENARIO_XML
@@ -280,4 +301,3 @@ case ARGV[0]
     usage
     exit
 end
-


### PR DESCRIPTION
Allows modules to be tested without creating a scenario file for each one, allowing us to not create scenarios that only contain one module for testing.
Added test-module command which requires --module [module_name] and --module-type [service,utility,vulnerability] options.
Other options include --basebox-type [linux,unix,windows] and --network-type [private_network, {public_network} <-- public network not included as not included in schema], {--network-range [ip_address, dhcp]} <-- network-range not included as complex error checking needed so will be added in a later pull request.
Error checking method (can be moved to a class later on) that includes all errors for test-module command, any other command error checking can be moved into here for optimisation if needed by using the case command in this method.

Works by creating a simple temp file that is then passed through the normal SecGen processing.

Should be fully working and hopefully will not conflict with the parameterisation branch that will be merged soon.
