### PR TITLE
Vulnerability: Shellshock in bash

### DIFF
--- a/lib/schemas/vulnerability_metadata_schema.xsd
+++ b/lib/schemas/vulnerability_metadata_schema.xsd
@@ -8,6 +8,7 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="user"/>
       <xs:enumeration value="root"/>
+      <xs:enumeration value="none"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="accessOptions">

--- a/modules/services/unix/http/apache_bash_cgi/apache_bash_cgi.pp
+++ b/modules/services/unix/http/apache_bash_cgi/apache_bash_cgi.pp
@@ -1,0 +1,1 @@
+require apache_bash_cgi::init

--- a/modules/services/unix/http/apache_bash_cgi/files/test.cgi
+++ b/modules/services/unix/http/apache_bash_cgi/files/test.cgi
@@ -1,0 +1,7 @@
+#!/bin/bash 
+echo "Content-type: text/plain"
+echo $(env)
+echo
+echo "Hi"
+bash --version
+bash /dev/null

--- a/modules/services/unix/http/apache_bash_cgi/manifests/init.pp
+++ b/modules/services/unix/http/apache_bash_cgi/manifests/init.pp
@@ -1,7 +1,11 @@
 class apache_bash_cgi::init {
+  file { '/usr/lib/cgi-bin/':
+    ensure => directory,
+  }
+
   file { '/usr/lib/cgi-bin/test.cgi':
+    ensure => file,
     source => 'puppet:///modules/apache_bash_cgi/test.cgi',
-    ensure => present,
     mode => '755',
   }
 }

--- a/modules/services/unix/http/apache_bash_cgi/manifests/init.pp
+++ b/modules/services/unix/http/apache_bash_cgi/manifests/init.pp
@@ -1,0 +1,7 @@
+class apache_bash_cgi::init {
+  file { '/usr/lib/cgi-bin/test.cgi':
+    source => 'puppet:///modules/apache_bash_cgi/test.cgi',
+    ensure => present,
+    mode => '755',
+  }
+}

--- a/modules/services/unix/http/apache_bash_cgi/secgen_metadata.xml
+++ b/modules/services/unix/http/apache_bash_cgi/secgen_metadata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+
+<service xmlns="http://www.github/cliffe/SecGen/service"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.github/cliffe/SecGen/service">
+  <name>Apache Bash CGI</name>
+  <author>Thomas Shaw</author>
+  <module_license>MIT</module_license>
+  <description>Hosts a bash CGI script on a default apache installation.</description>
+
+  <type>httpd</type>
+  <platform>unix</platform>
+
+  <reference>https://httpd.apache.org/</reference>
+  <software_license>Apache v2</software_license>
+
+  <requires>
+    <module_path>modules/services/unix/http/apache</module_path>
+  </requires>
+
+</service>

--- a/modules/vulnerabilities/unix/bash/shellshock/manifests/install.pp
+++ b/modules/vulnerabilities/unix/bash/shellshock/manifests/install.pp
@@ -1,0 +1,19 @@
+class shellshock::install{
+
+  file { '/usr/local/src/bash-4.1.tar.gz':
+    ensure => file,
+    source => 'puppet:///modules/shellshock/bash-4.1.tar.gz',
+  }
+
+  exec { 'unpack-bash-tar':
+    cwd         => '/usr/local/src',
+    command     => '/bin/tar -xzf /usr/local/src/bash-4.1.tar.gz',
+    creates     => '/usr/local/src/bash-4.1/',
+  }
+
+  exec { 'configure-make-make-install-bash':
+    cwd     => '/usr/local/src/bash-4.1/',
+    command => '/bin/bash /usr/local/src/bash-4.1/configure; /usr/bin/make; /usr/bin/make install;',
+    require => Exec['unpack-bash-tar'],
+  }
+}

--- a/modules/vulnerabilities/unix/bash/shellshock/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/bash/shellshock/secgen_metadata.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+
+<vulnerability xmlns="http://www.github/cliffe/SecGen/vulnerability"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.github/cliffe/SecGen/vulnerability">
+  <name>Bashbug / Shellshock</name>
+  <author>Thomas Shaw</author>
+  <module_license>MIT</module_license>
+  <description>Installs GNU bash version 4.1 which contains the bashbug / shellshock vulnerability.</description>
+
+  <type>bash</type>
+  <privilege>root</privilege>
+  <access>remote</access>
+  <platform>unix</platform>
+
+  <!--optional vulnerability details-->
+  <difficulty>medium</difficulty>
+  <cve>CVE-2014-6271</cve>
+  <cvss_base_score>10</cvss_base_score>
+  <cvss_vector>AV:N/AC:L/Au:N/C:C/I:C/A:C</cvss_vector>
+
+  <reference>https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6271</reference>
+  <reference>http://www.symantec.com/connect/blogs/shellshock-all-you-need-know-about-bash-bug-vulnerability</reference>
+  <software_name>bash</software_name>
+  <software_license>GPLv3+</software_license>
+
+</vulnerability>

--- a/modules/vulnerabilities/unix/bash/shellshock/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/bash/shellshock/secgen_metadata.xml
@@ -9,8 +9,8 @@
   <description>Installs GNU bash version 4.1 which contains the bashbug / shellshock vulnerability.</description>
 
   <type>bash</type>
-  <privilege>root</privilege>
-  <access>remote</access>
+  <privilege>none</privilege>
+  <access>local</access>
   <platform>unix</platform>
 
   <!--optional vulnerability details-->

--- a/modules/vulnerabilities/unix/bash/shellshock/shellshock.pp
+++ b/modules/vulnerabilities/unix/bash/shellshock/shellshock.pp
@@ -1,0 +1,1 @@
+include shellshock::install

--- a/scenarios/simple_examples/shellshock_apache_vulnerability.xml
+++ b/scenarios/simple_examples/shellshock_apache_vulnerability.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<scenario xmlns="http://www.github/cliffe/SecGen/scenario"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.github/cliffe/SecGen/scenario">
+
+  <system>
+    <system_name>storage_server</system_name>
+    <base platform="linux"/>
+
+    <service module_path="modules/services/unix/http/apache_bash_cgi"/>
+    <vulnerability module_path="modules/vulnerabilities/unix/bash/shellshock"/>
+
+    <network type="private_network" range="dhcp"/>
+  </system>
+
+</scenario>

--- a/scenarios/simple_examples/shellshock_vulnerability.xml
+++ b/scenarios/simple_examples/shellshock_vulnerability.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<scenario xmlns="http://www.github/cliffe/SecGen/scenario"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.github/cliffe/SecGen/scenario">
+
+  <system>
+    <system_name>storage_server</system_name>
+    <base platform="linux"/>
+
+    <vulnerability module_path="modules/vulnerabilities/unix/bash/shellshock"/>
+
+    <network type="private_network" range="dhcp"/>
+  </system>
+
+</scenario>


### PR DESCRIPTION
# Vulnerability: Shellshock in bash &  Service: Apache server with CGI hosting a bash script

New scenario combines the two modules & is exploitable with metasploit module: exploit/multi/http/apache_mod_cgi_bash_env_exec

## vulnerabilities/unix/bash/shellshock

Installs GNU Bash 4.1 from source

Tested using the [bashcheck](github.com/hannob/bashcheck) tool after installation.
![shellshock-bashcheck](https://cloud.githubusercontent.com/assets/3964474/18233975/5de193ac-72ee-11e6-9d96-4922cb4b5d76.png)

## services/unix/http/apache_bash_cgi

Hosts a bash script, test.cgi, on an apache server to demonstrate the remote exploitation of the shellshock vulnerability.

![shellshocked-1](https://cloud.githubusercontent.com/assets/3964474/18233980/766dc8c8-72ee-11e6-8f48-1bcb60190c89.png)
![shellshocked-2](https://cloud.githubusercontent.com/assets/3964474/18233981/7a8f2258-72ee-11e6-8fad-6ee0b07ede8f.png)

Cheers!
