### PR TITLE
Changes to access control misconfigurations vi uid root

### DIFF
--- a/modules/utilities/unix/system/accounts/accounts.pp
+++ b/modules/utilities/unix/system/accounts/accounts.pp
@@ -1,10 +1,13 @@
-accounts::user { 'user':
+$username = 'user'
+# Password = 'password'
+$password = '$6$$bLTg4cpho8PIUrjfsE7qlU08Qx2UEfw..xOc6I1wpGVtyVYToGrr7BzRdAAnEr5lYFr1Z9WcCf1xNZ1HG9qFW1'
+
+accounts::user { $username:
   uid      => '4001',
   gid      => '4001',
   shell    => '/bin/bash',
-  name => 'user',
-  # password = password
-  password => '$6$$bLTg4cpho8PIUrjfsE7qlU08Qx2UEfw..xOc6I1wpGVtyVYToGrr7BzRdAAnEr5lYFr1Z9WcCf1xNZ1HG9qFW1',
+  name => $username,
+  password => $password,
 
   # sshkeys  => "ssh-rsa AAAA...",
   # locked   => false,

--- a/modules/utilities/unix/system/change_file_uid/change_file_uid.pp
+++ b/modules/utilities/unix/system/change_file_uid/change_file_uid.pp
@@ -1,0 +1,3 @@
+# change_file_uid::change_uid_permissions {
+#   $user => 'root',
+# }

--- a/modules/utilities/unix/system/change_file_uid/manifests/change_uid_permissions.pp
+++ b/modules/utilities/unix/system/change_file_uid/manifests/change_uid_permissions.pp
@@ -1,0 +1,9 @@
+class change_file_uid::change_uid_permissions ($file_input = [],$user) {
+  $file_input.each |$file, $permission_code| {
+  file { $file:
+    mode => $permission_code,
+    owner => $user,
+  }
+  notice("File {$file} permissions have been checked.")
+}
+}

--- a/modules/utilities/unix/system/change_file_uid/secgen_metadata.xml
+++ b/modules/utilities/unix/system/change_file_uid/secgen_metadata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<utility xmlns="http://www.github/cliffe/SecGen/utility"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.github/cliffe/SecGen/utility">
+  <name>Change file uid module</name>
+  <author>Jason Keighley</author>
+  <module_license>Apache v2</module_license>
+  <description>Alter files to run with uid of given user</description>
+
+  <type>system</type>
+  <platform>linux</platform>
+
+</utility>

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/uid_vi_root/manifests/change_uid_permissions.pp
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/uid_vi_root/manifests/change_uid_permissions.pp
@@ -1,9 +1,0 @@
-class uid_vi_root::change_uid_permissions ($file_input = [],$user = 'root') {
-  $file_input.each |String $file, String $permission_code| {
-    file { $file:
-      mode => $permission_code,
-      owner => $user,
-    }
-  notice("File {$file} permissions have been checked.")
-  }
-}

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/uid_vi_root/manifests/change_uid_permissions_vi.pp
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/uid_vi_root/manifests/change_uid_permissions_vi.pp
@@ -1,0 +1,10 @@
+class uid_vi_root::change_uid_permissions_vi {
+  class { 'change_file_uid::change_uid_permissions':
+    file_input => {
+      '/usr/bin/vi'          => '4777',
+      '/etc/alternatives/vi' => '4777',
+      '/usr/bin/vim.tiny'    => '4777',
+    },
+    user => 'root',
+  }
+}

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/uid_vi_root/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/uid_vi_root/secgen_metadata.xml
@@ -22,7 +22,8 @@
   <!--Cannot co-exist with other installations-->
 
   <!-- Requires vi to run, already installed on debian systems -->
-  <!--<requires>-->
+  <requires>
     <!--<name>vi</name>-->
-  <!--</requires>-->
+    <module_path>modules/utilities/unix/system/change_file_uid</module_path>
+  </requires>
 </vulnerability>

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/uid_vi_root/uid_vi_root.pp
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/uid_vi_root/uid_vi_root.pp
@@ -1,7 +1,1 @@
-class {'uid_vi_root::change_uid_permissions':
-  file_input => {
-    '/usr/bin/vi' => '4777',
-    '/etc/alternatives/vi' => '4777',
-    '/usr/bin/vim.tiny'    => '4777',
-  }
-}
+include 'uid_vi_root::change_uid_permissions_vi'

--- a/scenarios/simple_examples/access_control_misconfigurations_uid_vi_root.xml
+++ b/scenarios/simple_examples/access_control_misconfigurations_uid_vi_root.xml
@@ -9,9 +9,11 @@
     <system_name>access_control_misconfigurations_vi_root</system_name>
     <base platform="linux"/>
 
-    <vulnerability module_path=".*uid_vi_root" type="access_control_misconfigurations"></vulnerability>
 
-    <network type="private_network" range="dhcp"></network>
+    <utility module_path="modules/utilities/unix/system/accounts"/>
+    <vulnerability module_path="modules/vulnerabilities/unix/access_control_misconfigurations/uid_vi_root"/>
+
+    <network type="private_network" range="dhcp"/>
   </system>
 
 </scenario>


### PR DESCRIPTION
Separates access control code and user account code from access control modules.
Stops duplicate code in access controls, other then the code that specifies which files are to be changed, and to which user.

Scenario file 'access_control_misconfigurations_uid_vi_root.xml'
Username = 'user'
Password = 'password'

Should be easier to do other uid access control modules, however some code may need to be changed to accommodate changes in pr #68.
