### PR TITLE
Private and public methods in Print.rb

### DIFF
--- a/lib/helpers/print.rb
+++ b/lib/helpers/print.rb
@@ -1,4 +1,3 @@
-
 class Print
   private
   def self.colorize(text, color_code)

--- a/lib/helpers/print.rb
+++ b/lib/helpers/print.rb
@@ -1,9 +1,11 @@
 
 class Print
+  private
   def self.colorize(text, color_code)
     "#{color_code}#{text}\e[0m"
   end
 
+  public
   def self.red(text); colorize(text, "\e[31m"); end
   def self.green(text); colorize(text, "\e[32m"); end
   def self.yellow(text); colorize(text, "\e[33m"); end


### PR DESCRIPTION
Changed print.rb colorize method to private method in an effort to increase security (ensure no unwanted code executed with the method).
This might not be needed, if not tell me and I will close pr #73