### PR TITLE
Service: ProFTPd

### DIFF
--- a/modules/services/unix/ftp/proftpd/manifests/configure.pp
+++ b/modules/services/unix/ftp/proftpd/manifests/configure.pp
@@ -1,0 +1,9 @@
+class proftpd::configure {
+  file { '/etc/proftpd/proftpd.conf':
+    ensure   => present,
+    owner    => 'root',
+    group    => 'root',
+    mode     => '0644',
+    content  => template('proftpd/proftpd.erb')
+  }
+}

--- a/modules/services/unix/ftp/proftpd/manifests/init.pp
+++ b/modules/services/unix/ftp/proftpd/manifests/init.pp
@@ -1,0 +1,5 @@
+class proftpd {
+  require proftpd::install
+  require proftpd::configure
+  require proftpd::service
+}

--- a/modules/services/unix/ftp/proftpd/manifests/install.pp
+++ b/modules/services/unix/ftp/proftpd/manifests/install.pp
@@ -1,0 +1,6 @@
+class proftpd::install {
+  package { 'proftpd':
+    ensure => installed,
+    name => 'proftpd',
+  }
+}

--- a/modules/services/unix/ftp/proftpd/manifests/service.pp
+++ b/modules/services/unix/ftp/proftpd/manifests/service.pp
@@ -1,0 +1,7 @@
+class proftpd::service {
+  service { 'proftpd':
+    ensure  => running,
+    enable  => true,
+    require => File['/etc/proftpd/proftpd.conf'],
+  }
+}

--- a/modules/services/unix/ftp/proftpd/proftpd.pp
+++ b/modules/services/unix/ftp/proftpd/proftpd.pp
@@ -1,0 +1,1 @@
+include proftpd

--- a/modules/services/unix/ftp/proftpd/secgen_metadata.xml
+++ b/modules/services/unix/ftp/proftpd/secgen_metadata.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+
+<service xmlns="http://www.github/cliffe/SecGen/service"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.github/cliffe/SecGen/service">
+  <name>vsftpd Server</name>
+  <author>Thomas Shaw</author>
+  <author>Adam J. Low</author>
+  <module_license>Apache v2</module_license>
+  <description>An installation of proftpd</description>
+
+  <type>ftp</type>
+  <platform>linux</platform>
+
+  <!--optional details-->
+  <reference>https://security.appspot.com/vsftpd.html</reference>
+  <reference>https://forge.puppet.com/adamjlow/proftpd</reference>
+  <software_name>proftpd</software_name>
+  <software_license>Apache v2</software_license>
+
+  <conflict>
+    <software_name>vsftpd</software_name>
+  </conflict>
+
+</service>

--- a/modules/services/unix/ftp/proftpd/secgen_metadata.xml
+++ b/modules/services/unix/ftp/proftpd/secgen_metadata.xml
@@ -22,4 +22,8 @@
     <software_name>vsftpd</software_name>
   </conflict>
 
+  <requires>
+    <module_path>utilities/unix/system/accounts</module_path>
+  </requires>
+
 </service>

--- a/modules/services/unix/ftp/proftpd/templates/proftpd.erb
+++ b/modules/services/unix/ftp/proftpd/templates/proftpd.erb
@@ -1,0 +1,189 @@
+#
+# /etc/proftpd/proftpd.conf -- This is a basic ProFTPD configuration file.
+# To really apply changes, reload proftpd after modifications, if
+# it runs in daemon mode. It is not required in inetd/xinetd mode.
+#
+
+# Includes DSO modules
+Include /etc/proftpd/modules.conf
+
+# Set off to disable IPv6 support which is annoying on IPv4 only boxes.
+UseIPv6				off
+# If set on you can experience a longer connection delay in many cases.
+IdentLookups			off
+
+ServerName			"Debian"
+ServerType			standalone
+DeferWelcome			off
+
+MultilineRFC2228		on
+DefaultServer			on
+ShowSymlinks			on
+
+TimeoutNoTransfer		600
+TimeoutStalled			600
+TimeoutIdle			1200
+
+DisplayLogin                    welcome.msg
+DisplayChdir               	.message true
+ListOptions                	"-l"
+
+DenyFilter			\*.*/
+
+# Use this to jail all users in their homes
+# DefaultRoot			~
+
+# Users require a valid shell listed in /etc/shells to login.
+# Use this directive to release that constrain.
+# RequireValidShell		off
+
+# Port 21 is the standard FTP port.
+Port				21
+
+# In some cases you have to specify passive ports range to by-pass
+# firewall limitations. Ephemeral ports can be used for that, but
+# feel free to use a more narrow range.
+# PassivePorts                  49152 65534
+
+# If your host was NATted, this option is useful in order to
+# allow passive tranfers to work. You have to use your public
+# address and opening the passive ports used on your firewall as well.
+# MasqueradeAddress		1.2.3.4
+
+# This is useful for masquerading address with dynamic IPs:
+# refresh any configured MasqueradeAddress directives every 8 hours
+<IfModule mod_dynmasq.c>
+  # DynMasqRefresh 28800
+</IfModule>
+
+# To prevent DoS attacks, set the maximum number of child processes
+# to 30.  If you need to allow more than 30 concurrent connections
+# at once, simply increase this value.  Note that this ONLY works
+# in standalone mode, in inetd mode you should use an inetd server
+# that allows you to limit maximum number of processes per service
+# (such as xinetd)
+MaxInstances			30
+
+# Set the user and group that the server normally runs at.
+User				root
+Group				nogroup
+
+# Umask 022 is a good standard umask to prevent new files and dirs
+# (second parm) from being group and world writable.
+Umask				022  022
+# Normally, we want files to be overwriteable.
+AllowOverwrite			on
+
+# Uncomment this if you are using NIS or LDAP via NSS to retrieve passwords:
+# PersistentPasswd		off
+
+# This is required to use both PAM-based authentication and local passwords
+# AuthOrder			mod_auth_pam.c* mod_auth_unix.c
+
+# Be warned: use of this directive impacts CPU average load!
+# Uncomment this if you like to see progress and transfer rate with ftpwho
+# in downloads. That is not needed for uploads rates.
+#
+# UseSendFile			off
+
+TransferLog /var/log/proftpd/xferlog
+SystemLog   /var/log/proftpd/proftpd.log
+
+# Logging onto /var/log/lastlog is enabled but set to off by default
+#UseLastlog on
+
+# In order to keep log file dates consistent after chroot, use timezone info
+# from /etc/localtime.  If this is not set, and proftpd is configured to
+# chroot (e.g. DefaultRoot or <!--<-->Anonymous<!-->-->), it will use the non-daylight
+  # savings timezone regardless of whether DST is in effect.
+  #SetEnv TZ :/etc/localtime
+
+  <IfModule mod_quotatab.c>
+    QuotaEngine off
+  </IfModule>
+
+  <IfModule mod_ratio.c>
+    Ratios off
+  </IfModule>
+
+
+  # Delay engine reduces impact of the so-called Timing Attack described in
+  # http://www.securityfocus.com/bid/11430/discuss
+  # It is on by default.
+  <IfModule mod_delay.c>
+    DelayEngine on
+  </IfModule>
+
+  <IfModule mod_ctrls.c>
+    ControlsEngine        off
+    ControlsMaxClients    2
+    ControlsLog           /var/log/proftpd/controls.log
+    ControlsInterval      5
+    ControlsSocket        /var/run/proftpd/proftpd.sock
+  </IfModule>
+
+  <IfModule mod_ctrls_admin.c>
+    AdminControlsEngine off
+  </IfModule>
+
+  #
+  # Alternative authentication frameworks
+  #
+  #Include /etc/proftpd/ldap.conf
+  #Include /etc/proftpd/sql.conf
+
+  #
+  # This is used for FTPS connections
+  #
+  #Include /etc/proftpd/tls.conf
+
+  #
+  # Useful to keep VirtualHost/VirtualRoot directives separated
+  #
+  #Include /etc/proftpd/virtuals.conf
+
+  # A basic anonymous configuration, no upload directories.
+
+  # <Anonymous ~ftp>
+  #   User				ftp
+  #   Group				nogroup
+  #   # We want clients to be able to login with "anonymous" as well as "ftp"
+  #   UserAlias			anonymous ftp
+  #   # Cosmetic changes, all files belongs to ftp user
+  #   DirFakeUser	on ftp
+  #   DirFakeGroup on ftp
+  #
+  #   RequireValidShell		off
+  #
+  #   # Limit the maximum number of anonymous logins
+  #   MaxClients			10
+  #
+  #   # We want 'welcome.msg' displayed at login, and '.message' displayed
+  #   # in each newly chdired directory.
+  #   DisplayLogin			welcome.msg
+  #   DisplayChdir		.message
+  #
+  #   # Limit WRITE everywhere in the anonymous chroot
+  #   <Directory *>
+  #     <Limit WRITE>
+  #       DenyAll
+  #     </Limit>
+  #   </Directory>
+  #
+  #   # Uncomment this if you're brave.
+  #   # <Directory incoming>
+  #   #   # Umask 022 is a good standard umask to prevent new files and dirs
+  #   #   # (second parm) from being group and world writable.
+  #   #   Umask				022  022
+  #   #            <Limit READ WRITE>
+  #   #            DenyAll
+  #   #            </Limit>
+  #   #            <Limit STOR>
+  #   #            AllowAll
+  #   #            </Limit>
+  #   # </Directory>
+  #
+  # </Anonymous>
+
+  # Include other custom configuration files
+  Include /etc/proftpd/conf.d/

--- a/scenarios/simple_examples/proftpd_service.xml
+++ b/scenarios/simple_examples/proftpd_service.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<scenario xmlns="http://www.github/cliffe/SecGen/scenario"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.github/cliffe/SecGen/scenario">
+
+	<!-- An example secure ftp server using the service proftpd -->
+	<system>
+		<system_name>proftpd_server</system_name>
+		<base platform="linux"/>
+
+		<service module_path="modules/services/unix/ftp/proftpd"></service>
+
+		<network type="private_network" range="dhcp"></network>
+	</system>
+
+</scenario>


### PR DESCRIPTION
Simple service module for ProFTPd.

ProFTPd uses PAM for authentication and has root FTP access disabled, so you may need to create a user on the VM to test.

![image](https://cloud.githubusercontent.com/assets/3964474/19369005/d085fffe-919a-11e6-8680-ca1b7c4be1b3.png)

Cheers,
Tom
