### PR TITLE
Multiple leaked files

### DIFF
--- a/lib/helpers/constants.rb
+++ b/lib/helpers/constants.rb
@@ -41,6 +41,9 @@ DOCUMENTATION_DIR = "#{ROOT_DIR}/documentation/yard/doc"
 # Path to resources
 WORDLISTS_DIR = "#{ROOT_DIR}/lib/resources/wordlists"
 
+# Path to secgen_functions puppet module
+SECGEN_FUNCTIONS_PUPPET_DIR = "#{MODULES_DIR}build/puppet/secgen_functions"
+
 ## VAGRANT FILE CONSTANTS ##
 
 #

--- a/lib/templates/Puppetfile.erb
+++ b/lib/templates/Puppetfile.erb
@@ -9,6 +9,7 @@
 forge "https://forgeapi.puppetlabs.com"
 
 mod 'puppetlabs-stdlib'  # stdlib enables parsejson() in manifests and other useful functions
+mod 'SecGen-secgen_functions', :path => '<%= SECGEN_FUNCTIONS_PUPPET_DIR %>'
 
 <% @currently_processing_system.module_selections.each do |selected_module| -%>
 <%   case selected_module.module_type

--- a/modules/build/puppet/secgen_functions/manifests/leak_file.pp
+++ b/modules/build/puppet/secgen_functions/manifests/leak_file.pp
@@ -1,0 +1,20 @@
+define secgen_functions::leak_file($leaked_filename, $storage_directory, $strings_to_leak, $owner = 'root', $group = 'root', $mode = '0777', $leaked_from = '' ) {
+  $path_to_leak = "$storage_directory/$leaked_filename"
+
+  # If the file already exists append to it, otherwise create it.
+  if (defined(File[$path_to_leak])){
+    notice("File with that name already defined, appending leaked strings instead...")
+    exec { "$leaked_from-$path_to_leak":
+      path    => ['/bin', '/usr/bin', '/usr/local/bin', '/sbin', '/usr/sbin'],
+      command => "echo $strings_to_leak >> $path_to_leak",
+    }
+  } else {
+    file { $path_to_leak:
+      ensure   => present,
+      owner    => $owner,
+      group    => $group,
+      mode     => $mode,
+      content  => template('secgen_functions/overshare.erb')
+    }
+  }
+}

--- a/modules/build/puppet/secgen_functions/manifests/leak_files.pp
+++ b/modules/build/puppet/secgen_functions/manifests/leak_files.pp
@@ -1,0 +1,34 @@
+define secgen_functions::leak_files($leaked_filenames, $storage_directory, $strings_to_leak, $owner = 'root', $group = 'root', $mode = '0777', $leaked_from) {
+
+  # $leaked_from is a mandatory resource specifying where the file was being leaked (i.e. which module / user leaked it.)
+  # This is to avoid resource clashes if two users get the same 'leaked_filenames' results
+  $leak_pairs = zip($strings_to_leak, $leaked_filenames)
+  $leak_pairs.each |$counter, $leak_pair| {
+      $leaked_strings = $leak_pair[0]
+      $leaked_filename = $leak_pair[1]
+
+      # until we run out of filenames, create a new file per string
+      unless $leaked_filename == undef {
+        $leaked_file_resource = "$leaked_from-$leaked_filename-$counter"
+        secgen_functions::leak_file { $leaked_file_resource:
+          leaked_filename          => $leaked_filename,
+          storage_directory        => $storage_directory,
+          strings_to_leak          => $leaked_strings,
+          owner                    => $owner,
+          mode                     => $mode,
+        }
+      } else {
+        # Then just add to first file.
+        $first_filename = $leaked_filenames[0]
+        $leaked_file_resource = "$leaked_from-$first_filename-$counter"
+        secgen_functions::leak_file { $leaked_file_resource:
+          leaked_filename          => $first_filename,
+          storage_directory        => $storage_directory,
+          strings_to_leak          => $leaked_strings,
+          owner                    => $owner,
+          mode                     => $mode,
+          leaked_from              => $leaked_file_resource,  # pass this in when appending to avoid resource clashes
+        }
+      }
+    }
+}

--- a/modules/build/puppet/secgen_functions/secgen_metadata.xml
+++ b/modules/build/puppet/secgen_functions/secgen_metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<build xmlns="http://www.github/cliffe/SecGen/build"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.github/cliffe/SecGen/build">
+  <name>SecGen Puppet Functions</name>
+  <author>Thomas Shaw</author>
+  <module_license>MIT</module_license>
+  <description>SecGen functions module encapuslates commonly used functions within secgen (e.g. leaking files,
+    overshare, flags etc.) into puppet resource statements.
+  </description>
+
+  <type>puppet</type>
+  <platform>linux</platform>
+
+  <!--optional details-->
+  <software_name>puppet</software_name>
+  <software_license>Apache v2</software_license>
+
+</build>

--- a/modules/build/puppet/secgen_functions/templates/overshare.erb
+++ b/modules/build/puppet/secgen_functions/templates/overshare.erb
@@ -1,0 +1,1 @@
+<%= @strings_to_leak %>

--- a/modules/encoders/account/account_hash_builder/secgen_local/local.rb
+++ b/modules/encoders/account/account_hash_builder/secgen_local/local.rb
@@ -5,7 +5,7 @@ class AccountHashBuilder < StringEncoder
   attr_accessor :input_password
   attr_accessor :input_super_user
   attr_accessor :input_strings_to_leak
-  attr_accessor :input_leaked_filename
+  attr_accessor :input_leaked_filenames
 
   def initialize
     super
@@ -14,7 +14,7 @@ class AccountHashBuilder < StringEncoder
     self.input_password = ''
     self.input_super_user = ''
     self.input_strings_to_leak = []
-    self.input_leaked_filename = ''
+    self.input_leaked_filenames = []
   end
 
   def encode_all
@@ -23,7 +23,7 @@ class AccountHashBuilder < StringEncoder
     account_hash['password'] = self.input_password
     account_hash['super_user'] = self.input_super_user
     account_hash['strings_to_leak'] = self.input_strings_to_leak
-    account_hash['leaked_filename'] = self.input_leaked_filename
+    account_hash['leaked_filenames'] = self.input_leaked_filenames
 
     self.outputs << account_hash
   end
@@ -34,7 +34,7 @@ class AccountHashBuilder < StringEncoder
         [ '--help', '-h', GetoptLong::NO_ARGUMENT ],
         [ '--strings_to_encode', '-s', GetoptLong::OPTIONAL_ARGUMENT ],
         [ '--strings_to_leak', GetoptLong::OPTIONAL_ARGUMENT ],
-        [ '--leaked_filename', GetoptLong::OPTIONAL_ARGUMENT ],
+        [ '--leaked_filenames', GetoptLong::OPTIONAL_ARGUMENT ],
         [ '--username', GetoptLong::REQUIRED_ARGUMENT ],
         [ '--password', GetoptLong::REQUIRED_ARGUMENT ],
         [ '--super_user', GetoptLong::REQUIRED_ARGUMENT ],
@@ -53,8 +53,8 @@ class AccountHashBuilder < StringEncoder
           self.input_super_user << arg;
         when '--strings_to_leak'
           self.input_strings_to_leak << arg;
-        when '--leaked_filename'
-          self.input_leaked_filename << arg;
+        when '--leaked_filenames'
+          self.input_leaked_filenames << arg;
         else
           Print.err "Argument not valid: #{arg}"
           usage
@@ -68,7 +68,7 @@ class AccountHashBuilder < StringEncoder
     password: ' + self.input_password.to_s  + ',
     super_user: ' + self.input_super_user.to_s + ',
     strings_to_leak: ' + self.input_strings_to_leak.to_s + ',
-    leaked_filename: ' + self.input_leaked_filename.to_s
+    leaked_filenames: ' + self.input_leaked_filenames.to_s
   end
 end
 

--- a/modules/encoders/account/account_hash_builder/secgen_metadata.xml
+++ b/modules/encoders/account/account_hash_builder/secgen_metadata.xml
@@ -17,7 +17,7 @@
   <read_fact>password</read_fact>
   <read_fact>super_user</read_fact>
   <read_fact>strings_to_leak</read_fact>
-  <read_fact>leaked_filename</read_fact>
+  <read_fact>leaked_filenames</read_fact>
 
   <!-- TODO: This encoder should have default values so that we can omit a default input -->
 

--- a/modules/generators/random/random_common_password/secgen_metadata.xml
+++ b/modules/generators/random/random_common_password/secgen_metadata.xml
@@ -11,6 +11,7 @@
   </description>
 
   <type>password_generator</type>
+  <type>weak_password_generator</type>
   <type>local_calculation</type>
   <platform>linux</platform>
   <platform>windows</platform>

--- a/modules/generators/random/random_weak_password/secgen_metadata.xml
+++ b/modules/generators/random/random_weak_password/secgen_metadata.xml
@@ -9,6 +9,7 @@
   <description>Selects a random dictionary word or english name between 3 and 6 characters long. </description>
 
   <type>password_generator</type>
+  <type>weak_password_generator</type>
   <type>local_calculation</type>
   <platform>linux</platform>
   <platform>windows</platform>

--- a/modules/services/unix/http/apache/templates/overshare.erb
+++ b/modules/services/unix/http/apache/templates/overshare.erb
@@ -1,2 +1,0 @@
-<% require 'json' -%>
-<%= JSON.parse(@json_inputs)["strings_to_leak"].join("\n----\n") %>

--- a/modules/services/unix/smb/samba/templates/overshare.erb
+++ b/modules/services/unix/smb/samba/templates/overshare.erb
@@ -1,2 +1,0 @@
-<% require 'json' -%>
-<%= JSON.parse(@json_inputs)["strings_to_leak"].join("\n----\n") %>

--- a/modules/vulnerabilities/unix/irc/unrealirc_3281_backdoor/manifests/configure.pp
+++ b/modules/vulnerabilities/unix/irc/unrealirc_3281_backdoor/manifests/configure.pp
@@ -1,6 +1,8 @@
 class unrealirc_3281_backdoor::configure {
 
   $secgen_parameters = parsejson($::json_inputs)
+  $strings_to_leak = $secgen_parameters['strings_to_leak']
+  $leaked_filenames = $secgen_parameters['leaked_filenames']
   $user = $secgen_parameters['user'][0]
   $group = $secgen_parameters['group'][0]
   $motd = $secgen_parameters['motd'][0]
@@ -31,12 +33,16 @@ class unrealirc_3281_backdoor::configure {
     command => 'cat ircd.motd2 > ircd.motd'
   }
 
-  # Leak file and share extras
-  file { "$user_home/$leaked_filename":
-    ensure  => present,
-    owner   => $user,
-    group   => $group,
-    mode    => '0777',
-    content  => template('unrealirc_3281_backdoor/overshare.erb')
+  # Create $user_home dir
+  file { $user_home:
+    ensure => directory,
+  }
+
+  ::secgen_functions::leak_files { 'unrealirc_3281-file-leak':
+    storage_directory => $user_home,
+    leaked_filenames  => $leaked_filenames,
+    strings_to_leak   => $strings_to_leak,
+    owner             => $user,
+    leaked_from       => "unrealirc_3281_backdoor",
   }
 }

--- a/modules/vulnerabilities/unix/irc/unrealirc_3281_backdoor/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/irc/unrealirc_3281_backdoor/secgen_metadata.xml
@@ -16,7 +16,7 @@
   <platform>linux</platform>
 
   <read_fact>strings_to_leak</read_fact>
-  <read_fact>leaked_filename</read_fact>
+  <read_fact>leaked_filenames</read_fact>
   <read_fact>server_name</read_fact>
   <read_fact>server_desc</read_fact>
   <read_fact>admin_name</read_fact>
@@ -30,7 +30,8 @@
     <generator type="message_generator"/>
   </default_input>
 
-  <default_input into="leaked_filename">
+  <default_input into="leaked_filenames">
+    <generator module_path="generators/filenames/leaked_filename"/>
     <generator module_path="generators/filenames/leaked_filename"/>
   </default_input>
 

--- a/modules/vulnerabilities/unix/irc/unrealirc_3281_backdoor/templates/overshare.erb
+++ b/modules/vulnerabilities/unix/irc/unrealirc_3281_backdoor/templates/overshare.erb
@@ -1,2 +1,0 @@
-<% require 'json' -%>
-<%= JSON.parse(@json_inputs)["strings_to_leak"].join("\n----\n") %>

--- a/modules/vulnerabilities/unix/misc/distcc_exec/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/misc/distcc_exec/secgen_metadata.xml
@@ -14,14 +14,14 @@
   <platform>unix</platform>
 
   <read_fact>strings_to_leak</read_fact>
-  <read_fact>leaked_filename</read_fact>
+  <read_fact>leaked_filenames</read_fact>
 
   <default_input into="strings_to_leak">
     <generator type="message_generator"/>
     <generator type="message_generator"/>
   </default_input>
 
-  <default_input into="leaked_filename">
+  <default_input into="leaked_filenames">
     <generator module_path="generators/filenames/leaked_filename"/>
   </default_input>
 

--- a/modules/vulnerabilities/unix/misc/distcc_exec/templates/overshare.erb
+++ b/modules/vulnerabilities/unix/misc/distcc_exec/templates/overshare.erb
@@ -1,2 +1,0 @@
-<% require 'json' -%>
-<%= JSON.parse(@json_inputs)["strings_to_leak"].join("\n----\n") %>

--- a/modules/vulnerabilities/unix/nfs/nfs_overshare/manifests/config.pp
+++ b/modules/vulnerabilities/unix/nfs/nfs_overshare/manifests/config.pp
@@ -2,7 +2,8 @@ class nfs_overshare::config {
 
   # Setup SecGen Parameters
   $secgen_parameters=parsejson($::json_inputs)
-  $leaked_filename=$secgen_parameters['leaked_filename'][0]
+  $leaked_filenames=$secgen_parameters['leaked_filenames']
+  $strings_to_leak=$secgen_parameters['strings_to_leak']
   $storage_directory=$secgen_parameters['storage_directory'][0]
 
   package { ['nfs-kernel-server', 'nfs-common', 'portmap']:
@@ -33,19 +34,10 @@ class nfs_overshare::config {
     # path    => [ "/usr/local/bin/", "/bin/" ],  # alternative syntax
   }
 
-  file { "$storage_directory/$leaked_filename":
-    require => Package['nfs-common'],
-    ensure  => present,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0777',
-    content  => template('nfs_overshare/overshare.erb')
+  ::secgen_functions::leak_files { 'nfs_overshare-file-leak':
+    storage_directory => $storage_directory,
+    leaked_filenames => $leaked_filenames,
+    strings_to_leak => $strings_to_leak,
+    leaked_from => "nfs_overshare",
   }
-
-  # file { '/tmp/file02':
-  #   ensure  => file,
-  #   content => 'Yeah, I am file02, so what?',
-  # }
-  # strings_to_leak_location
-
 }

--- a/modules/vulnerabilities/unix/nfs/nfs_overshare/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/nfs/nfs_overshare/secgen_metadata.xml
@@ -14,13 +14,13 @@
   <platform>linux</platform>
 
   <read_fact>strings_to_leak</read_fact>
-  <read_fact>leaked_filename</read_fact>
+  <read_fact>leaked_filenames</read_fact>
   <read_fact>storage_directory</read_fact>
 
   <!--if an input is not specified in the scenario-->
   <default_input into="strings_to_leak">
     <value>Plain text from the metadata default, destined for strings_to_leak...</value>
-    <encoder>
+    <encoder type="string_encoder">
       <input into="strings_to_encode">
         <!--encode the following strings-->
         <value>Encoded text from the metadata default, destined for strings_to_leak...</value>
@@ -28,10 +28,12 @@
         <generator module_path=".*random.*"/>
       </input>
     </encoder>
+    <generator type="message_generator"/>
   </default_input>
 
   <!-- File-name which contains strings_to_leak -->
-  <default_input into="leaked_filename">
+  <default_input into="leaked_filenames">
+    <generator module_path="generators/filenames/leaked_filename"/>
     <generator module_path="generators/filenames/leaked_filename"/>
   </default_input>
 

--- a/modules/vulnerabilities/unix/nfs/nfs_overshare/templates/overshare.erb
+++ b/modules/vulnerabilities/unix/nfs/nfs_overshare/templates/overshare.erb
@@ -1,2 +1,0 @@
-<% require 'json' -%>
-<%= JSON.parse(@json_inputs)["strings_to_leak"].join("\n----\n") %>

--- a/modules/vulnerabilities/unix/smb/samba_public_writable_share/manifests/install.pp
+++ b/modules/vulnerabilities/unix/smb/samba_public_writable_share/manifests/install.pp
@@ -3,7 +3,8 @@ class samba_public_writable_share::install {
 
   $secgen_parameters = parsejson($::json_inputs)
   $storage_directory = $secgen_parameters['storage_directory'][0]
-  $leaked_filename = $secgen_parameters['leaked_filename'][0]
+  $leaked_filenames = $secgen_parameters['leaked_filenames']
+  $strings_to_leak = $secgen_parameters['strings_to_leak']
 
   # Ensure the storage directory exists
   file { $storage_directory:
@@ -29,13 +30,10 @@ class samba_public_writable_share::install {
    order => '02',
  }
 
-  # Leak file and share extras
-  file { "$storage_directory/$leaked_filename":
-    ensure  => present,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0777',
-    content  => template('samba/overshare.erb')
+  ::secgen_functions::leak_files { 'samba_public_writable_share-file-leak':
+    storage_directory => $storage_directory,
+    leaked_filenames  => $leaked_filenames,
+    strings_to_leak   => $strings_to_leak,
+    leaked_from       => 'samba_public_writable_share',
   }
-
 }

--- a/modules/vulnerabilities/unix/smb/samba_public_writable_share/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/smb/samba_public_writable_share/secgen_metadata.xml
@@ -15,7 +15,7 @@
   <platform>linux</platform>
 
   <read_fact>strings_to_leak</read_fact>
-  <read_fact>leaked_filename</read_fact>
+  <read_fact>leaked_filenames</read_fact>
   <read_fact>share_name</read_fact>
   <read_fact>storage_directory</read_fact>
   <read_fact>read_only_share</read_fact>
@@ -24,7 +24,7 @@
   <!--if an input is not specified in the scenario-->
   <default_input into="strings_to_leak">
     <value>Plain text from the metadata default, destined for strings_to_leak...</value>
-    <encoder>
+    <encoder type="string_encoder">
       <input into="strings_to_encode">
         <!--encode the following strings-->
         <value>Encoded text from the metadata default, destined for strings_to_leak...</value>
@@ -33,7 +33,8 @@
     </encoder>
   </default_input>
 
-  <default_input into="leaked_filename">
+  <default_input into="leaked_filenames">
+    <generator module_path="generators/filenames/leaked_filename"/>
     <generator module_path="generators/filenames/leaked_filename"/>
   </default_input>
 

--- a/modules/vulnerabilities/unix/smb/samba_symlink_traversal/manifests/install.pp
+++ b/modules/vulnerabilities/unix/smb/samba_symlink_traversal/manifests/install.pp
@@ -3,7 +3,8 @@ class samba_symlink_traversal::install {
 
   $secgen_parameters = parsejson($::json_inputs)
   $storage_directory = $secgen_parameters['storage_directory'][0]
-  $leaked_filename = $secgen_parameters['leaked_filename'][0]
+  $leaked_filenames = $secgen_parameters['leaked_filenames']
+  $strings_to_leak = $secgen_parameters['strings_to_leak']
   $symlink_traversal = true
 
   # Ensure the storage directory exists
@@ -35,12 +36,10 @@ class samba_symlink_traversal::install {
     command => "/bin/sed -i \'/\\[global\\]/a allow insecure wide links = yes\' /etc/samba/smb.conf"
   }
 
-  # Leak file and share extras
-  file { "$storage_directory/$leaked_filename":
-    ensure  => present,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0777',
-    content  => template('samba/overshare.erb')
+  ::secgen_functions::leak_files { 'samba_symlink_traversal-file-leak':
+    storage_directory => $storage_directory,
+    leaked_filenames  => $leaked_filenames,
+    strings_to_leak   => $strings_to_leak,
+    leaked_from       => 'samba_symlink_traversal',
   }
 }

--- a/modules/vulnerabilities/unix/smb/samba_symlink_traversal/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/smb/samba_symlink_traversal/secgen_metadata.xml
@@ -15,7 +15,7 @@
   <platform>linux</platform>
 
   <read_fact>strings_to_leak</read_fact>
-  <read_fact>leaked_filename</read_fact>
+  <read_fact>leaked_filenames</read_fact>
   <read_fact>share_name</read_fact>
   <read_fact>storage_directory</read_fact>
   <read_fact>read_only_share</read_fact>
@@ -24,7 +24,7 @@
   <!--if an input is not specified in the scenario-->
   <default_input into="strings_to_leak">
     <value>Plain text from the metadata default, destined for strings_to_leak...</value>
-    <encoder>
+    <encoder type="string_encoder">
       <input into="strings_to_encode">
         <!--encode the following strings-->
         <value>Encoded text from the metadata default, destined for strings_to_leak...</value>
@@ -33,7 +33,8 @@
     </encoder>
   </default_input>
 
-  <default_input into="leaked_filename">
+  <default_input into="leaked_filenames">
+    <generator module_path="generators/filenames/leaked_filename"/>
     <generator module_path="generators/filenames/leaked_filename"/>
   </default_input>
 

--- a/modules/vulnerabilities/unix/system/parameterised_accounts/manifests/account.pp
+++ b/modules/vulnerabilities/unix/system/parameterised_accounts/manifests/account.pp
@@ -1,4 +1,4 @@
-define parameterised_accounts::account($username, $password, $super_user, $strings_to_leak, $leaked_filename) {
+define parameterised_accounts::account($username, $password, $super_user, $strings_to_leak, $leaked_filenames) {
   ::accounts::user { $username:
     shell      => '/bin/bash',
     password   => pw_hash($password, 'SHA-512', 'mysalt'),
@@ -14,7 +14,11 @@ define parameterised_accounts::account($username, $password, $super_user, $strin
   }
 
   # Leak strings in a text file in the users home directory
-  file { "/home/$username/$leaked_filename":
-    content => template('parameterised_accounts/overshare.erb')
+  ::secgen_functions::leak_files { "$username-file-leak":
+    storage_directory => "/home/$username/",
+    leaked_filenames  => $leaked_filenames,
+    strings_to_leak   => $strings_to_leak,
+    owner             => $username,
+    leaked_from       => "accounts_$username",
   }
 }

--- a/modules/vulnerabilities/unix/system/parameterised_accounts/manifests/init.pp
+++ b/modules/vulnerabilities/unix/system/parameterised_accounts/manifests/init.pp
@@ -3,12 +3,13 @@ class parameterised_accounts::init {
 
   $accounts = $secgen_parameters['accounts']
   $accounts.each |$account| {
-      parameterised_accounts::account { "parameterised-$account-name":
-        username        => $account['username'],
+      $username = $account['username']
+      parameterised_accounts::account { "parameterised-$username":
+        username        => $username,
         password        => $account['password'],
         super_user      => str2bool($account['super_user']),
         strings_to_leak => $account['strings_to_leak'],
-        leaked_filename => $account['leaked_filename']
+        leaked_filenames => $account['leaked_filenames']
       }
     }
 }

--- a/modules/vulnerabilities/unix/system/parameterised_accounts/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/system/parameterised_accounts/secgen_metadata.xml
@@ -15,7 +15,6 @@
   <platform>linux</platform>
 
   <read_fact>accounts</read_fact>
-  <read_fact>strings_to_leak</read_fact>
 
   <default_input into="accounts">
     <encoder type="account">
@@ -23,10 +22,10 @@
         <generator type="username_generator"/>
       </input>
       <input into="password">
-        <generator type="password_generator"/>
+        <generator type="weak_password_generator"/>
       </input>
       <input into="super_user">
-        <generator type="boolean_generator"/>
+        <value>false</value>
       </input>
       <input into="strings_to_leak">
         <generator type="message_generator"/>

--- a/modules/vulnerabilities/unix/system/parameterised_accounts/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/system/parameterised_accounts/secgen_metadata.xml
@@ -32,7 +32,8 @@
         <generator type="message_generator"/>
         <generator type="message_generator"/>
       </input>
-      <input into="leaked_filename">
+      <input into="leaked_filenames">
+        <generator module_path="generators/filenames/leaked_filename"/>
         <generator module_path="generators/filenames/leaked_filename"/>
       </input>
     </encoder>

--- a/modules/vulnerabilities/unix/system/parameterised_accounts/templates/overshare.erb
+++ b/modules/vulnerabilities/unix/system/parameterised_accounts/templates/overshare.erb
@@ -1,2 +1,0 @@
-<%= @strings_to_leak.join("\n----\n") %>
-

--- a/modules/vulnerabilities/unix/webapp/gitlist_040/manifests/configure.pp
+++ b/modules/vulnerabilities/unix/webapp/gitlist_040/manifests/configure.pp
@@ -1,7 +1,8 @@
 class gitlist_040::configure {
 
   $secgen_parameters = parsejson($::json_inputs)
-  $leaked_filename = $secgen_parameters['leaked_filename'][0]
+  $leaked_filenames = $secgen_parameters['leaked_filenames']
+  $strings_to_leak = $secgen_parameters['strings_to_leak']
   $github_repository = $secgen_parameters['github_repository'][0]
 
   Exec { path => ['/bin', '/usr/bin', '/usr/local/bin', '/sbin', '/usr/sbin'] }
@@ -31,11 +32,12 @@ class gitlist_040::configure {
     redirect_dest   => '/gitlist/',
   }
 
-  # Overshare, file leak
-  file { "/var/www/gitlist/$leaked_filename":
-    ensure  => present,
-    owner   => 'www-data',
-    mode    => '0750',
-    content  => template('apache/overshare.erb')
+  ::secgen_functions::leak_files { 'gitlist_040-file-leak':
+    storage_directory => '/var/www/gitlist/',
+    leaked_filenames  => $leaked_filenames,
+    strings_to_leak   => $strings_to_leak,
+    owner             => 'www-data',
+    mode              => '0750',
+    leaked_from       => 'gitlist_040',
   }
 }

--- a/modules/vulnerabilities/unix/webapp/gitlist_040/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/webapp/gitlist_040/secgen_metadata.xml
@@ -18,7 +18,7 @@
   <platform>linux</platform>
 
   <read_fact>strings_to_leak</read_fact>
-  <read_fact>leaked_filename</read_fact>
+  <read_fact>leaked_filenames</read_fact>
   <read_fact>github_repository</read_fact>
 
   <default_input into="strings_to_leak">
@@ -26,7 +26,8 @@
     <generator type="message_generator"/>
   </default_input>
 
-  <default_input into="leaked_filename">
+  <default_input into="leaked_filenames">
+    <generator module_path="generators/filenames/leaked_filename"/>
     <generator module_path="generators/filenames/leaked_filename"/>
   </default_input>
 

--- a/modules/vulnerabilities/unix/webapp/gitlist_040/templates/overshare.erb
+++ b/modules/vulnerabilities/unix/webapp/gitlist_040/templates/overshare.erb
@@ -1,2 +1,0 @@
-<% require 'json' -%>
-<%= JSON.parse(@json_inputs)["strings_to_leak"].join("\n----\n") %>

--- a/scenarios/parameterised_examples/parameterised_accounts.xml
+++ b/scenarios/parameterised_examples/parameterised_accounts.xml
@@ -24,7 +24,7 @@
 					<input into="strings_to_leak">
 						<generator type="message_generator"/>
 					</input>
-					<input into="leaked_filename">
+					<input into="leaked_filenames">
 						<generator module_path="generators/filenames/leaked_filename"/>
 					</input>
 				</encoder>


### PR DESCRIPTION
We can now leak strings to multiple files with different filenames.
New builds/secgen_functions module encapsulating the file_leak and overshare.erb logic into a puppet resource statement. Updated old modules to use the new resource type.