### PR TITLE
Adds the Windows 2008 r2 server 64 bit basebox, allows for no license.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You will need to install the following:
 
 Ruby: https://www.ruby-lang.org/en/  
 Vagrant: http://www.vagrantup.com/  
+Packer: https://www.packer.io/downloads.html  
 Virtual Box: https://www.virtualbox.org/  
 Puppet: http://puppet.com/  
 And the required Ruby Gems (including Nokogiri and Librarian-puppet)

--- a/lib/helpers/constants.rb
+++ b/lib/helpers/constants.rb
@@ -48,6 +48,13 @@ WORDLISTS_DIR = "#{ROOT_DIR}/lib/resources/wordlists"
 # Path to secgen_functions puppet module
 SECGEN_FUNCTIONS_PUPPET_DIR = "#{MODULES_DIR}build/puppet/secgen_functions"
 
+## PACKER CONSTANTS ##
+
+# Path to Packerfile.erb file
+PUPPET_VERSION = '3.8.7'
+
+VAGRANT_BASEBOX_STORAGE = "#{ROOT_DIR}/.generated"
+
 ## VAGRANT FILE CONSTANTS ##
 
 #

--- a/lib/output/project_files_creator.rb
+++ b/lib/output/project_files_creator.rb
@@ -45,6 +45,38 @@ class ProjectFilesCreator
       template_based_file_write(PUPPET_TEMPLATE_FILE, pfile)
       Print.std 'Preparing puppet modules using librarian-puppet'
       GemExec.exe('librarian-puppet', path, 'install')
+
+      system.module_selections.each do |selected_module|
+
+        if selected_module.module_type == 'base'
+          url = selected_module.attributes['url'].first
+
+          unless url.nil? || url =~ /^http*/
+            Print.std "Checking to see if local basebox #{url.split('/').last} exists"
+            packerfile_path = "#{BASES_DIR}#{selected_module.attributes['packerfile_path'].first}"
+            autounattend_path = "#{BASES_DIR}#{selected_module.attributes['packerfile_path'].first.split('/').first}/Autounattend.xml.erb"
+
+            unless File.file? "#{VAGRANT_BASEBOX_STORAGE}/#{url}"
+              Print.std "Basebox #{url.split('/').last} not found, searching for packerfile"
+
+              if File.file? packerfile_path
+                Print.info "Would you like to use the packerfile to create the packerfile from the given url (y/n)"
+                (Print.info "Exiting as vagrant needs the basebox to continue"; exit) unless ['y','yes'].include?(STDIN.gets.chomp.downcase)
+
+                Print.std "Packerfile #{packerfile_path.split('/').last} found, building basebox #{url.split('/').last} via packer"
+                template_based_file_write(packerfile_path, packerfile_path.split(/.erb$/).first)
+                template_based_file_write(autounattend_path, autounattend_path.split(/.erb$/).first)
+                system "cd '#{packerfile_path.split(/\/[^\/]*.erb$/).first}' && packer build Packerfile && cd '#{ROOT_DIR}'"
+              else
+                Print.err "Packerfile not found, vagrant error may occur, please check the secgen metadata for the base module #{selected_module.name} for errors";
+              end
+            else
+              Print.std "Vagrant basebox #{url.split('/').last} exists"
+              selected_module.attributes['url'][0] = "#{VAGRANT_BASEBOX_STORAGE}/#{url}"
+            end
+          end
+        end
+      end
     end
 
     vfile = "#{@out_dir}/Vagrantfile"

--- a/lib/schemas/base_metadata_schema.xsd
+++ b/lib/schemas/base_metadata_schema.xsd
@@ -8,6 +8,7 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="linux"/>
       <xs:enumeration value="unix"/>
+      <xs:enumeration value="windows"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -40,6 +41,9 @@
         <xs:element name="platform" type="platformOptions" minOccurs="1" maxOccurs="unbounded"/>
         <xs:element name="distro" type="xs:string" minOccurs="1" maxOccurs="1"/>
         <xs:element name="url" type="xs:string" minOccurs="1" maxOccurs="1"/>
+
+        <xs:element name="packerfile_path" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="product_key" type="xs:string" minOccurs="0" maxOccurs="1"/>
 
         <!--optional details-->
         <xs:element name="reference" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>

--- a/lib/schemas/vulnerability_metadata_schema.xsd
+++ b/lib/schemas/vulnerability_metadata_schema.xsd
@@ -29,6 +29,7 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="linux"/>
       <xs:enumeration value="unix"/>
+      <xs:enumeration value="windows"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="difficultyOptions">

--- a/lib/templates/Vagrantfile.erb
+++ b/lib/templates/Vagrantfile.erb
@@ -18,17 +18,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     else
 "      vb.gui = false
       vb.customize ['modifyvm', :id, '--pae', 'on']
-      vb.customize ['modifyvm', :id, '--hwvirtex', 'off']
+      vb.customize ['modifyvm', :id, '--hwvirtex', 'on']
       vb.customize ['modifyvm', :id, '--vtxvpid', 'off']"
-    end -%>
+    end %>
 <%= if (@options.has_key? :memory_per_vm)
 "      vb.memory = #{@options[:memory_per_vm]}"
     elsif (@options.has_key? :total_memory)
 "      vb.memory = #{@options[:total_memory]}/#{@systems.length}"
-    end -%>
+    end %>
 <%= if (@options.has_key? :max_cpu_cores)
 "      vb.cpus = #{@options[:max_cpu_cores]}"
-    end -%>
+    end %>
 <%= if (@options.has_key? :max_cpu_usage)
 "      vb.customize ['modifyvm', :id, '--cpuexecutioncap', '#{@options[:max_cpu_usage]}']"
     end %>
@@ -45,7 +45,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
      when 'base' -%>
     <%= system.name %>.vm.box = "<%= selected_module.module_path_name %>"
     <%= system.name %>.vm.box_url = "<%= selected_module.attributes['url'].first %>"
-<%   when 'network' -%>
+
+    <% if (selected_module.attributes['platform'].first.downcase == 'windows') %>
+    config.vm.communicator = 'winrm'
+    config.vm.guest = :windows
+    config.vm.network :forwarded_port, guest: 3389, host: 3389
+    config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
+    <% end %>
+
+        <%   when 'network' -%>
 <%     if selected_module.attributes['range'].first.nil? || selected_module.attributes['range'].first == "dhcp" -%>
     <%= system.name %>.vm.network :<%= selected_module.attributes['type'].first %>, type: "dhcp"
 <%     else -%>

--- a/modules/bases/windows_server_2008_r2_amd64/Autounattend.xml.erb
+++ b/modules/bases/windows_server_2008_r2_amd64/Autounattend.xml.erb
@@ -1,0 +1,311 @@
+<% @systems.each do |system| -%>
+<% system.module_selections.each do |selected_module| -%>
+<% if selected_module.module_type == 'base' -%>
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <servicing/>
+    <settings pass="windowsPE">
+        <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DiskConfiguration>
+                <Disk wcm:action="add">
+                    <CreatePartitions>
+                        <CreatePartition wcm:action="add">
+                            <Order>1</Order>
+                            <Type>Primary</Type>
+                            <Extend>true</Extend>
+                        </CreatePartition>
+                    </CreatePartitions>
+                    <ModifyPartitions>
+                        <ModifyPartition wcm:action="add">
+                            <Extend>false</Extend>
+                            <Format>NTFS</Format>
+                            <Letter>C</Letter>
+                            <Order>1</Order>
+                            <PartitionID>1</PartitionID>
+                            <Label>Windows 2008R2</Label>
+                        </ModifyPartition>
+                    </ModifyPartitions>
+                    <DiskID>0</DiskID>
+                    <WillWipeDisk>true</WillWipeDisk>
+                </Disk>
+                <WillShowUI>OnError</WillShowUI>
+            </DiskConfiguration>
+            <UserData>
+                <AcceptEula>true</AcceptEula>
+                <FullName>Vagrant Administrator</FullName>
+                <Organization>Vagrant Inc.</Organization>
+                <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                <ProductKey>
+                    <!-- Do not uncomment the Key element if you are using trial ISOs -->
+                    <!-- You must uncomment the Key element (and optionally insert your own key) if you are using retail or volume license ISOs -->
+                    <!--<Key>YC6KT-GKW9T-YTKYR-T4X34-R7VHC</Key>-->
+                    <!--<Key>YC6KT-GKW9T-YTKYR-T4X34-R7VHC</Key>-->
+                    <%= selected_module.attributes.has_key?('product_key') ?  "<Key>#{selected_module.attributes['product_key'].first}</Key>" : '<!--<Key></Key>-->'; %>
+                    <WillShowUI>Never</WillShowUI>
+                </ProductKey>
+            </UserData>
+            <ImageInstall>
+                <OSImage>
+                    <InstallTo>
+                        <DiskID>0</DiskID>
+                        <PartitionID>1</PartitionID>
+                    </InstallTo>
+                    <WillShowUI>OnError</WillShowUI>
+                    <InstallToAvailablePartition>false</InstallToAvailablePartition>
+                    <InstallFrom>
+                        <MetaData wcm:action="add">
+                            <Key>/IMAGE/NAME</Key>
+                            <Value>Windows Server 2008 R2 SERVERSTANDARD</Value>
+                        </MetaData>
+                    </InstallFrom>
+                </OSImage>
+            </ImageInstall>
+        </component>
+        <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <SetupUILanguage>
+                <UILanguage>en-US</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+        </component>
+    </settings>
+    <settings pass="offlineServicing">
+        <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <EnableLUA>false</EnableLUA>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <UserAccounts>
+                <AdministratorPassword>
+                    <Value>vagrant</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>vagrant</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Description>Vagrant User</Description>
+                        <DisplayName>vagrant</DisplayName>
+                        <Group>administrators</Group>
+                        <Name>vagrant</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+            </UserAccounts>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <NetworkLocation>Home</NetworkLocation>
+            </OOBE>
+            <AutoLogon>
+                <Password>
+                    <Value>vagrant</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Username>vagrant</Username>
+                <Enabled>true</Enabled>
+            </AutoLogon>
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c powershell -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+                    <Description>Set Execution Policy 64 Bit</Description>
+                    <Order>1</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>C:\Windows\SysWOW64\cmd.exe /c powershell -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+                    <Description>Set Execution Policy 32 Bit</Description>
+                    <Order>2</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm quickconfig -q</CommandLine>
+                    <Description>winrm quickconfig -q</Description>
+                    <Order>3</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm quickconfig -transport:http</CommandLine>
+                    <Description>winrm quickconfig -transport:http</Description>
+                    <Order>4</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</CommandLine>
+                    <Description>Win RM MaxTimoutms</Description>
+                    <Order>5</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="800"}</CommandLine>
+                    <Description>Win RM MaxMemoryPerShellMB</Description>
+                    <Order>6</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxShellsPerUser="999"}</CommandLine>
+                    <Description>Win RM MaxShellsPerUser</Description>
+                    <Order>7</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm set winrm/config/winrs @{MaxProcessesPerShell="999"}</CommandLine>
+                    <Description>Win RM MaxProcessesPerShell</Description>
+                    <Order>8</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm set winrm/config/service @{MaxConcurrentOperationsPerUser="999"}</CommandLine>
+                    <Description>Win RM ConcurrentOperationsPerUser</Description>
+                    <Order>9</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</CommandLine>
+                    <Description>Win RM AllowUnencrypted</Description>
+                    <Order>10</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</CommandLine>
+                    <Description>Win RM auth Basic</Description>
+                    <Order>11</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</CommandLine>
+                    <Description>Win RM client auth Basic</Description>
+                    <Order>12</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm set winrm/config/listener?Address=*+Transport=HTTP @{Port="5985"} </CommandLine>
+                    <Description>Win RM listener Address/Port</Description>
+                    <Order>13</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes </CommandLine>
+                    <Description>Win RM adv firewall enable</Description>
+                    <Order>14</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985" </CommandLine>
+                    <Description>Win RM port open</Description>
+                    <Order>15</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c net stop winrm </CommandLine>
+                    <Description>Stop Win RM Service </Description>
+                    <Order>16</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c sc config winrm start= auto</CommandLine>
+                    <Description>Win RM Autostart</Description>
+                    <Order>17</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c net start winrm</CommandLine>
+                    <Description>Start Win RM Service</Description>
+                    <Order>18</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\ /v HideFileExt /t REG_DWORD /d 0 /f</CommandLine>
+                    <Order>19</Order>
+                    <Description>Show file extensions in Explorer</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKCU\Console /v QuickEdit /t REG_DWORD /d 1 /f</CommandLine>
+                    <Order>20</Order>
+                    <Description>Enable QuickEdit mode</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\ /v Start_ShowRun /t REG_DWORD /d 1 /f</CommandLine>
+                    <Order>21</Order>
+                    <Description>Show Run command in Start Menu</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\ /v StartMenuAdminTools /t REG_DWORD /d 1 /f</CommandLine>
+                    <Order>22</Order>
+                    <Description>Show Administrative Tools in Start Menu</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\Power\ /v HibernateFileSizePercent /t REG_DWORD /d 0 /f</CommandLine>
+                    <Order>23</Order>
+                    <Description>Zero Hibernation File</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\Power\ /v HibernateEnabled /t REG_DWORD /d 0 /f</CommandLine>
+                    <Order>24</Order>
+                    <Description>Disable Hibernation Mode</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c wmic useraccount where "name='vagrant'" set PasswordExpires=FALSE</CommandLine>
+                    <Order>25</Order>
+                    <Description>Disable password expiration for vagrant user</Description>
+                </SynchronousCommand>
+                <!-- WITHOUT WINDOWS UPDATES -->
+                <SynchronousCommand wcm:action="add">
+					<CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\openssh.ps1 -AutoStart</CommandLine>
+					<Description>Install OpenSSH</Description>
+					<Order>99</Order>
+					<RequiresUserInput>true</RequiresUserInput>
+				</SynchronousCommand>
+                <!-- END WITHOUT WINDOWS UPDATES -->
+                <!-- WITH WINDOWS UPDATES -->
+                <!--<SynchronousCommand wcm:action="add">-->
+                    <!--<CommandLine>cmd.exe /c a:\microsoft-updates.bat</CommandLine>-->
+                    <!--<Order>98</Order>-->
+                    <!--<Description>Enable Microsoft Updates</Description>-->
+                <!--</SynchronousCommand>-->
+                <!--<SynchronousCommand wcm:action="add">-->
+                    <!--<CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\win-updates.ps1 -MaxUpdatesPerCycle 30</CommandLine>-->
+                    <!--<Description>Install Windows Updates</Description>-->
+                    <!--<Order>100</Order>-->
+                    <!--<RequiresUserInput>true</RequiresUserInput>-->
+                <!--</SynchronousCommand>-->
+                <!-- END WITH WINDOWS UPDATES -->
+            </FirstLogonCommands>
+            <ShowWindowsLive>false</ShowWindowsLive>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <OEMInformation>
+                <HelpCustomized>false</HelpCustomized>
+            </OEMInformation>
+            <!-- Rename computer here. -->
+            <ComputerName>vagrant-2008R2</ComputerName>
+            <TimeZone>Pacific Standard Time</TimeZone>
+            <RegisteredOwner/>
+        </component>
+        <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DoNotOpenServerManagerAtLogon>true</DoNotOpenServerManagerAtLogon>
+        </component>
+        <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-IE-ESC" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <!--  Disable IE ESC.  -->
+            <IEHardenAdmin>false</IEHardenAdmin>
+            <IEHardenUser>false</IEHardenUser>
+        </component>
+        <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-OutOfBoxExperience" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DoNotOpenInitialConfigurationTasksAtLogon>true</DoNotOpenInitialConfigurationTasksAtLogon>
+        </component>
+        <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <SkipAutoActivation>true</SkipAutoActivation>
+        </component>
+    </settings>
+    <cpi:offlineImage xmlns:cpi="urn:schemas-microsoft-com:cpi" cpi:source="catalog:d:/sources/install_windows server 2008 r2 serverdatacenter.clg"/>
+</unattend>
+<% end -%>
+<% end -%>
+<% end -%>

--- a/modules/bases/windows_server_2008_r2_amd64/Packerfile.erb
+++ b/modules/bases/windows_server_2008_r2_amd64/Packerfile.erb
@@ -1,0 +1,55 @@
+{
+"builders": [{
+"type": "virtualbox-iso",
+"headless": <%= !(@options.has_key?(:gui_output)) %>,
+"vboxmanage": [
+<%= if (@options.has_key? :memory_per_vm)
+      "[ \"modifyvm\", \"{{.Name}}\", \"--memory\", \"#{@options[:memory_per_vm]}\" ],"
+    elsif (@options.has_key? :total_memory)
+      "[ \"modifyvm\", \"{{.Name}}\", \"--memory\", \"#{@options[:total_memory]/@systems.length}\" ],"
+    end %>
+<%= if (@options.has_key? :max_cpu_cores)
+      "[ \"modifyvm\", \"{{.Name}}\", \"--cpus\", \"#{@options[:max_cpu_cores]}\" ],"
+    end %>
+<%= if (@options.has_key? :max_cpu_usage)
+      "[ \"modifyvm\", \"{{.Name}}\", \"--cpuexecutioncap\", \"#{@options[:max_cpu_usage]}\" ],"
+    end %>
+[ "modifyvm", "{{.Name}}", "--natpf1", "winrm,tcp,,5985,,5985" ]
+],
+"guest_os_type": "Windows2008_64",
+"disk_size": 61440,
+"iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+"iso_checksum": "4263be2cf3c59177c45085c0a7bc6ca5",
+"iso_checksum_type": "md5",
+"communicator": "winrm",
+"winrm_username": "vagrant",
+"winrm_password": "vagrant",
+"winrm_port": "5985",
+"winrm_timeout": "5h",
+"guest_additions_mode": "attach",
+"guest_additions_path": "Z:",
+"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+"shutdown_timeout": "1h",
+"floppy_files": [
+"Autounattend.xml"
+]
+}],
+"provisioners": [
+{
+"type": "windows-shell",
+"script": "<%= 'virtualbox_guest_install/windows.bat' -%>"
+},
+{
+"type": "powershell",
+"environment_vars": "PuppetVersion=<%= PUPPET_VERSION -%>",
+"script": "<%= 'puppet_install/windows.ps1' -%>"
+}
+],
+"post-processors": [
+{
+"type": "vagrant",
+"keep_input_artifact": false,
+"output": "<%= "#{VAGRANT_BASEBOX_STORAGE}/windows_2008_64_virtualbox.box" -%>"
+}
+]
+}

--- a/modules/bases/windows_server_2008_r2_amd64/puppet_install/LICENSE
+++ b/modules/bases/windows_server_2008_r2_amd64/puppet_install/LICENSE
@@ -1,0 +1,374 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.
+

--- a/modules/bases/windows_server_2008_r2_amd64/puppet_install/windows.ps1
+++ b/modules/bases/windows_server_2008_r2_amd64/puppet_install/windows.ps1
@@ -1,0 +1,68 @@
+<#
+.SYNOPSIS
+    Installs Puppet on this machine.
+
+.DESCRIPTION
+    Downloads and installs the PuppetLabs Puppet MSI package.
+
+    This script requires administrative privileges.
+
+    You can run this script from an old-style cmd.exe prompt using the
+    following:
+
+      powershell.exe -ExecutionPolicy Unrestricted -NoLogo -NoProfile -Command "& '.\windows.ps1'"
+
+.PARAMETER MsiUrl
+    This is the URL to the Puppet MSI file you want to install. This defaults
+    to a version from PuppetLabs.
+
+.PARAMETER PuppetVersion
+    This is the version of Puppet that you want to install. If you pass this it will override the version in the MsiUrl.
+    This defaults to $null.
+#>
+param(
+   # [string]$MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-3.3.2.msi"
+   [string]$MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-3.8.7.msi"
+  ,[string]$PuppetVersion = $null
+)
+
+if ($PuppetVersion) {
+  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-$($PuppetVersion).msi"
+  Write-Host "Puppet version $PuppetVersion specified, updated MsiUrl to `"$MsiUrl`""
+}
+
+$PuppetInstalled = $false
+try {
+  $ErrorActionPreference = "Stop";
+  Get-Command puppet | Out-Null
+  $PuppetInstalled = $true
+  $PuppetVersion=&puppet "--version"
+  Write-Host "Puppet $PuppetVersion is installed. This process does not ensure the exact version or at least version specified, but only that puppet is installed. Exiting..."
+  Exit 0
+} catch {
+  Write-Host "Puppet is not installed, continuing..."
+}
+
+if (!($PuppetInstalled)) {
+  $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+  if (! ($currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))) {
+    Write-Host -ForegroundColor Red "You must run this script as an administrator."
+    Exit 1
+  }
+
+  # Install it - msiexec will download from the url
+  $install_args = @("/qn", "/norestart","/i", $MsiUrl)
+  Write-Host "Installing Puppet. Running msiexec.exe $install_args"
+  $process = Start-Process -FilePath msiexec.exe -ArgumentList $install_args -Wait -PassThru
+  if ($process.ExitCode -ne 0) {
+    Write-Host "Installer failed."
+    Exit 1
+  }
+
+  # Stop the service that it autostarts
+  Write-Host "Stopping Puppet service that is running by default..."
+  Start-Sleep -s 5
+  Stop-Service -Name puppet
+
+  Write-Host "Puppet successfully installed."
+}

--- a/modules/bases/windows_server_2008_r2_amd64/secgen_metadata.xml
+++ b/modules/bases/windows_server_2008_r2_amd64/secgen_metadata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+
+<base xmlns="http://www.github/cliffe/SecGen/base"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.github/cliffe/SecGen/base">
+  <name>Windows 2008 Virtualbox puppet 64</name>
+  <author>Jason Keighley</author>
+  <module_license>Apache v2</module_license>
+  <description>Packer built basebox for windows server 2008 64 bit virtualbox </description>
+  <type>server</type>
+
+  <platform>windows</platform>
+  <distro>Windows 2008 r2</distro>
+  <url>windows_2008_64_virtualbox.box</url> <!-- Check for this basebox first -->
+
+  <packerfile_path>windows_server_2008_r2_amd64/Packerfile.erb</packerfile_path> <!-- If basebox not found build new basebox via packerfile at path -->
+
+  <reference></reference>
+  <software_license>various</software_license>
+
+</base>

--- a/modules/bases/windows_server_2008_r2_amd64/virtualbox_guest_install/windows.bat
+++ b/modules/bases/windows_server_2008_r2_amd64/virtualbox_guest_install/windows.bat
@@ -1,0 +1,9 @@
+@echo off
+echo "Changing directory to Virtualbox certificate directory"
+cd /d "E:\cert"
+echo "Installing VirtualBox certificates"
+for %%i in (vbox*.cer) do VBoxCertUtil add-trusted-publisher %%i --root %%i
+echo "Changing directory to VirtualBox guest main directory"
+cd /d "E:\"
+echo "Installing VirtualBox guest additions"
+VBoxWindowsAdditions.exe /S

--- a/scenarios/windows_scenario.xml
+++ b/scenarios/windows_scenario.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<scenario xmlns="http://www.github/cliffe/SecGen/scenario"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.github/cliffe/SecGen/scenario">
+
+	<!-- an example remote storage system, with a remotely exploitable vulnerability that can then be escalated to root -->
+	<system>
+		<system_name>storage_server</system_name>
+		<!--<base platform="windows" name="Windows 2008 Virtualbox puppet 32"/>-->
+		<base platform="windows" name="Windows 2008 Virtualbox puppet 64"/>
+
+		<network type="private_network" range="dhcp"/>
+	</system>
+
+</scenario>


### PR DESCRIPTION
Will download ISO from microsoft site, will then build basebox (storing in VAGRANT_BASEBOX_STORAGE) and will then build with vagrant.
If Basebox is not present SecGen will prompt whether to use packer (requires download from packer website in README.md and for the binary to be in the system path) to build the Basebox.

*** Changes ***
constants.rb
51-57: Added the 2 constants PUPPET_VERSION: version of puppet to install on the newly generated system, and VAGRANT_BASEBOX_STORAGE which stores generated baseboxes (currently set to SecGen_root/.generated).

project_files_creator.rb
48-80: Added logic to check for existing basebox and to generate new basebox if not present.

base_metadata_schema.xsd
11: Added windows to platform options type
45-50: Added extra packer helper tags, packerfile_path (path to packer file in the layout of base_module_name/Packerfile_name) and product_key (will use a trial version if product key is not present)

vulnerability_metadata_schema.xsd
32: Added windows value to platformOptions type to allow for windows system implementation.

Vagrantfile.erb
21: Changed --hwvirtex to default of on without gui output, problems can occur if this is not set to on.
23,28,31: Removed - tags before ending %>, this was causing an error with the vagrantfile as the options were not being placed on different lines.
48-56: Added the use of winrm instead of the default ssh for the base module if the base module is windows.

puppet_install/LICENSE
Added Mozilla Public License Version 2.0 (GPL v3 compatable) that came with the puppet_install/windows.ps1 script, the script to install puppet can be rewritten with a more simple implementation, however this script should do error checking to add an extra level of stability to the puppet install.

puppet_install/windows.ps1
Will install puppet on the Windows machine.

virtualbox_guest_install/windows.bat
Will install the virtualbox guest additions on the Windows machine.

Autounattend.xml.erb
Aurounattend script that allows for setting out the system layout including system information, disk configuration and product keys.

Packerfile.erb
Packerfile that builds the machine via packer, was going to be fully parameterised with all options being in the SecGen metadata (it still can be converted to this easily) however this lead to a large SecGen_metadata file with multiple tags which were only used if the basebox is not present, therefore only the product_key and packerfile_path keys were added to the SecGen_metadata file. Although the product_key data may be moved to a central product_key file later on.

secgen_metadata.xml
SecGen metadata file for the new windows basebox.