### PR TITLE
Bug fix: create back up folder if not exist

### DIFF
--- a/lib/batch/batch_secgen.rb
+++ b/lib/batch/batch_secgen.rb
@@ -238,6 +238,7 @@ def start(options)
         log.close
 
         # Back up project flags, scenario, and log file
+        FileUtils.mkdir_p("#{backup_path}#{project_id}") unless Dir.exist?("#{backup_path}#{project_id}")
         FileUtils.cp(log_path, ("#{backup_path}#{project_id}/" + log_name))
         FileUtils.cp("#{project_path}/#{FLAGS_FILENAME}", "#{backup_path}#{project_id}/")
         FileUtils.cp("#{project_path}/scenario.xml", "#{backup_path}#{project_id}/")


### PR DESCRIPTION
When copying flags, scenario, and log file, create back up project folder if not exist.
If the folder does not exist, Fileutil.cp can not copy file, Fileutil.cp through exception.

-----

How to produce this error:
$ ruby lib/batch/batch_secgen.rb add --instances tom,cliffe --- run
$ ruby lib/batch/batch_secgen.rb start

Summary of Error:
```
batch_secgen.rb:241:in `block in start'
fileutils.rb:1386:in `initialize': No such file or directory
```