### PR TITLE
Improved code to grant XSS flag - fixes Issue #196.

### DIFF
--- a/modules/generators/html/vuln_snippets/xss_search_template/secgen_local/local.rb
+++ b/modules/generators/html/vuln_snippets/xss_search_template/secgen_local/local.rb
@@ -41,12 +41,14 @@ class XSSsearchTemplateGenerator < StringEncoder
     medium_blacklist_insert = "\'" + blacklist_array[0] + "\',\'" + blacklist_array[1] + "\',\'" + blacklist_array[2] + "\'"
 
     # The snippets of code below are taken from lauras code and edited slightly
-    flag_statement = "if(in_array($search, $payloads)){
-                        ?>
-                        <div id=\"sucess\">
-                          #{strings_to_leak}
-                        </div>
-                        <?php
+    flag_statement = "$pattern=\"/<(?i)script>(confirm|prompt|alert)\\(([^'\\\"]*)\\);?<\\/script>/\";
+                        if(preg_match($pattern, $search)){
+                          ?>
+                          <div class=\"alert alert-info\">
+                            Well done, you have successfully exploited a cross-site scripting vulnerability!<br/>
+                            Here is a flag: #{strings_to_leak}
+                          </div>
+                         <?php
                     }
                   }"
 


### PR DESCRIPTION
Implementation improved using regex instead of a hardcoded list of payloads. Most common usages of script tags will work and grant the flag, e.g. `<script>alert(document.cookie);</script>`. Best when used at "easy" level, i.e. without blacklisting keywords. 

This is an easy flag which most students should get straight away. There are still holes in the implementation, but these should hopefully remain unnoticed if students "find the flag and move on". 

If a purely flag-based method of scoring is to be used, this release should also contain more difficult challenges, possibly as part of #197 .