### PR TITLE
change repos to use debian archive

### DIFF
--- a/modules/vulnerabilities/unix/http/apache_druid_rce/files/stretch.list
+++ b/modules/vulnerabilities/unix/http/apache_druid_rce/files/stretch.list
@@ -1,2 +1,2 @@
-deb http://deb.debian.org/debian/ stretch main
-deb-src http://deb.debian.org/debian stretch main
+deb http://archive.debian.org/debian/ stretch main
+deb-src http://archive.debian.org/debian stretch main

--- a/modules/vulnerabilities/unix/http/jenkins_cli/files/stretch.list
+++ b/modules/vulnerabilities/unix/http/jenkins_cli/files/stretch.list
@@ -1,2 +1,2 @@
-deb http://deb.debian.org/debian/ stretch main
-deb-src http://deb.debian.org/debian stretch main
+deb http://archive.debian.org/debian/ stretch main
+deb-src http://archive.debian.org/debian stretch main


### PR DESCRIPTION
Recent changes to debian repositories, mean stretch is being archived from this point on. These updates reflect those changes. 