### PR TITLE
String of fixes to MoinMoin

### DIFF
--- a/modules/generators/image/random_jpg/secgen_local/local.rb
+++ b/modules/generators/image/random_jpg/secgen_local/local.rb
@@ -18,7 +18,7 @@ class ImageGenerator < StringEncoder
 
     images = Magick::ImageList.new
     images.read(self.selected_image_path)
-    images.new_image(images.first.columns, images.first.rows) { self.background_color = 'white' } # Create new "layer" with white background and size of original image
+    images.new_image(images.first.columns, images.first.rows) { background_color = 'white' } # Create new "layer" with white background and size of original image
     image = images.reverse.flatten_images
 
     image.write(tmp_file_path)

--- a/modules/vulnerabilities/unix/webapp/moinmoin_195/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/webapp/moinmoin_195/secgen_metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <vulnerability xmlns="http://www.github/cliffe/SecGen/vulnerability"
-               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://www.github/cliffe/SecGen/vulnerability">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.github/cliffe/SecGen/vulnerability">
 
   <name>MoinMoin v1.9.5</name>
   <author>Thomas Shaw</author>
@@ -35,20 +35,21 @@
     <value>80</value>
   </default_input>
 
-  <!-- TODO: should strings_to_leak be hidden away on the server, so the exploit needs exploiting before getting to the files, at the moment browsing to the website reveals the files -->
+  <!-- TODO: should strings_to_leak be hidden away on the server, so the exploit needs exploiting
+  before getting to the files, at the moment browsing to the website reveals the files -->
   <default_input into="strings_to_leak">
-    <generator type="message_generator"/>
+    <generator type="message_generator" />
   </default_input>
   <default_input into="leaked_filenames">
-    <generator type="filename_generator"/>
+    <generator type="filename_generator" />
   </default_input>
 
   <default_input into="strings_to_pre_leak">
-    <generator type="message_generator"/>
+    <generator type="message_generator" />
   </default_input>
 
   <default_input into="images_to_leak">
-    <generator type="image_generator"/>
+    <generator type="image_generator" />
   </default_input>
 
   <default_input into="site_name">
@@ -59,7 +60,8 @@
     <value>Default Page Test</value>
   </default_input>
 
-  <!--optional vulnerability details-->
+  <!--optional
+  vulnerability details-->
   <cve>CVE-2012-6080</cve>
   <cve>CVE-2012-6081</cve>
 
@@ -71,7 +73,8 @@
   <software_name>moinmoin</software_name>
   <software_license>GPL</software_license>
 
-  <!--optional hints-->
+  <!--optional
+  hints-->
   <msf_module>exploit/unix/webapp/moinmoin_twikidraw</msf_module>
   <solution>
     Remote code execution possible in twikidraw and anywikidraw modules.
@@ -84,23 +87,23 @@
   </conflict>
 
   <requires>
-    <module_path>.*/apache.*</module_path>
+    <module_path>.*apache.*compatible.*</module_path>
   </requires>
 
   <CyBOK KA="WAM" topic="Server-Side Vulnerabilities and Mitigations">
     <keyword>server-side misconfiguration and vulnerable components</keyword>
     <keyword>Directory traversal</keyword>
   </CyBOK>
-	<CyBOK KA="MAT" topic="Attacks and exploitation">
-		<keyword>EXPLOITATION</keyword>
-		<keyword>EXPLOITATION FRAMEWORKS</keyword>
-	</CyBOK>
-	<CyBOK KA="SS" topic="Categories of Vulnerabilities">
-		<keyword>CVEs and CWEs</keyword>
-	</CyBOK>
-	<CyBOK KA="SOIM" topic="PENETRATION TESTING">
-		<keyword>PENETRATION TESTING - SOFTWARE TOOLS</keyword>
-		<keyword>PENETRATION TESTING - ACTIVE PENETRATION</keyword>
-	</CyBOK>
+  <CyBOK KA="MAT" topic="Attacks and exploitation">
+    <keyword>EXPLOITATION</keyword>
+    <keyword>EXPLOITATION FRAMEWORKS</keyword>
+  </CyBOK>
+  <CyBOK KA="SS" topic="Categories of Vulnerabilities">
+    <keyword>CVEs and CWEs</keyword>
+  </CyBOK>
+  <CyBOK KA="SOIM" topic="PENETRATION TESTING">
+    <keyword>PENETRATION TESTING - SOFTWARE TOOLS</keyword>
+    <keyword>PENETRATION TESTING - ACTIVE PENETRATION</keyword>
+  </CyBOK>
 
 </vulnerability>


### PR DESCRIPTION
The MoinMoin module is pretty much outdated at this point regarding the base image -> This will most likely need a newer Debian version built within vagrant. 

This causes issues regarding the "update" module since Debian Wheezy is long gone at this point refreshing packages thus causes errors with refreshing packages. This also somewhat correlates to the issue #275 in where updating repository packages causes issues. 

These are a start to a string of fixes to keep the module more in line. Most notably, some of the generator (image_generator **type**) modules have been causing a few errors pre-provisioning and thus stopping progression.

**Done**
- So far this fixes the random_jpg

**TODO:**
- steghide module needs some work; This module also causes some errors. 
- Either:
  - New base image (To allow Debian to refresh) - Preferable option
  - Apt repo files need to point to debian snapshot (As discussed in #275)