### PR TITLE
Fix module naming errors

### DIFF
--- a/modules/vulnerabilities/unix/access_control_misconfigurations/setuid_root_nmap/manifests/init.pp
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/setuid_root_nmap/manifests/init.pp
@@ -1,4 +1,4 @@
-class setuid_nmap::init {
+class setuid_root_nmap::init {
   $secgen_parameters = secgen_functions::get_parameters($::base64_inputs_file)
   $leaked_filenames = $secgen_parameters['leaked_filenames']
   $strings_to_leak = $secgen_parameters['strings_to_leak']
@@ -11,9 +11,9 @@ class setuid_nmap::init {
   # Leak a file containing a string/flag to /root/
   ::secgen_functions::leak_files { 'setuid_nmap-file-leak':
     storage_directory => '/root',
-    leaked_filenames => $leaked_filenames,
-    strings_to_leak => $strings_to_leak,
-    leaked_from => "setuid_nmap",
-    mode => '0600'
+    leaked_filenames  => $leaked_filenames,
+    strings_to_leak   => $strings_to_leak,
+    leaked_from       => 'setuid_nmap',
+    mode              => '0600'
   }
 }

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/setuid_root_nmap/setuid_root_nmap.pp
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/setuid_root_nmap/setuid_root_nmap.pp
@@ -1,1 +1,1 @@
-include setuid_nmap::init
+include setuid_root_nmap::init


### PR DESCRIPTION
Error popped up if this module was used due to the naming. 