### PR TITLE
Disastrous Development lab

### DIFF
--- a/modules/vulnerabilities/unix/http/lucee_rce/manifests/install.pp
+++ b/modules/vulnerabilities/unix/http/lucee_rce/manifests/install.pp
@@ -13,8 +13,6 @@ class lucee_rce::install {
   $user = $secgen_parameters['unix_username'][0]
   $user_home = "/home/${user}"
 
-  ensure_packages(['openjdk-11-jdk'], { ensure => 'installed'})
-
   $splits.each |String $split| {
     file { "/tmp/${split}":
       ensure => file,
@@ -27,6 +25,25 @@ class lucee_rce::install {
     ensure     => present,
     home       => $user_home,
     managehome => true,
+  }
+  exec { 'download-jdk11':
+    cwd     => '/tmp',
+    command => 'wget -O jdk11.tar.gz https://download.java.net/openjdk/jdk11.0.0.2/ri/openjdk-11.0.0.2_linux-x64.tar.gz',
+    creates => '/tmp/jdk11.tar.gz',
+    timeout => 300,
+  }
+  -> exec { 'extract-jdk11':
+    cwd     => '/tmp',
+    command => 'tar -xzf jdk11.tar.gz',
+    creates => '/tmp/jdk-11.0.0.2',
+  }
+  -> file { '/usr/lib/jvm':
+    ensure => directory,
+  }
+  -> exec { 'install-jdk11':
+    cwd     => '/tmp',
+    command => 'mv jdk-11.0.0.2 /usr/lib/jvm/java-11-openjdk',
+    creates => '/usr/lib/jvm/java-11-openjdk',
   }
 
   exec { 'rebuild-archive':

--- a/modules/vulnerabilities/unix/http/lucee_rce/templates/lucee.service.erb
+++ b/modules/vulnerabilities/unix/http/lucee_rce/templates/lucee.service.erb
@@ -3,6 +3,7 @@ Description=Lucee
 [Service]
 Type=forking
 User=<%= @user %>
+Environment="JAVA_HOME=/usr/lib/jvm/java-11-openjdk"
 ExecStart=/usr/local/src/bin/startup.sh
 ExecStop=/usr/local/src/bin/shutdown.sh
 TimeoutStopSec=5

--- a/scenarios/ctf/disastrous_development.xml
+++ b/scenarios/ctf/disastrous_development.xml
@@ -87,7 +87,7 @@
 
     <system>
         <system_name>lucee_web</system_name>
-        <base distro="Debian 10" type="desktop" name="KDE" />
+        <base distro="Debian 12" type="desktop" name="KDE" />
 
         <vulnerability module_path=".*/lucee_rce">
             <input into="strings_to_leak">


### PR DESCRIPTION
- Couldn't get openjdk version 11 on debian 12 from apt so changed to get it from java.net. This now installs correctly and changed the JAVA_HOME environment variable to match.
- The scenario is exploitable via a Lucee exploit leading to a shell which then gives the flag.
- **Only 1 flag in this scenario so I can change it to add a priv esc flag if you'd like?**