### PR TITLE
Container Escape Lab

### DIFF
--- a/modules/utilities/unix/container/docker/docker.pp
+++ b/modules/utilities/unix/container/docker/docker.pp
@@ -2,12 +2,12 @@ $secgen_params = secgen_functions::get_parameters($::base64_inputs_file)
 $images = $secgen_params['images']
 
 # install
-include 'docker'
+# include 'docker'
 
 # TODO: configure proxy via secgen argument?
-#class { 'docker':
-#  proxy => "http://172.22.0.51:3128",
-#}
+class { 'docker':
+  proxy => "http://172.22.0.51:3128",
+}
 
 
 # remove proxy config (it's in the template, and this overrides)
@@ -47,11 +47,11 @@ include 'docker'
 # }
 
 # remove proxy config (it's in the template, and this overrides)
-exec { 'remove_docker_proxy_conf':
-  command => 'sudo rm /etc/systemd/system/docker.service.d/*proxy.conf',
-  path    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
-  onlyif  => 'test -d /etc/systemd/system/docker.service.d && ls /etc/systemd/system/docker.service.d/*proxy.conf',
-}
+# exec { 'remove_docker_proxy_conf':
+#   command => 'sudo rm /etc/systemd/system/docker.service.d/*proxy.conf',
+#   path    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
+#   onlyif  => 'test -d /etc/systemd/system/docker.service.d && ls /etc/systemd/system/docker.service.d/*proxy.conf',
+# }
 
 # download (pull) a set of images
 $images.each |$image| {

--- a/scenarios/ctf/container_escape.xml
+++ b/scenarios/ctf/container_escape.xml
@@ -44,7 +44,7 @@
 
   <system>
     <system_name>desktop</system_name>
-    <base distro="Debian 9" type="desktop" name="KDE"/>
+    <base distro="Debian 12" type="desktop" name="KDE"/>
 
     <input into_datastore="IP_addresses">
       <value>172.16.0.2</value>
@@ -151,7 +151,7 @@
     <utility module_path=".*/docker">
       <input into="images">
         <value>ubuntu:xenial</value>
-        <value>debian:stretch</value>
+        <value>debian:bookworm</value>
         <value>busybox</value>
       </input>
     </utility>
@@ -188,7 +188,7 @@
 
   <system>
     <system_name>chroot_esc_server</system_name>
-    <base distro="Debian 9" type="desktop" name="KDE"/>
+    <base distro="Debian 12" type="desktop" name="KDE"/>
 
     <utility module_path=".*/handy_cli_tools"/>
     <utility module_path=".*/nmap"/>


### PR DESCRIPTION
- Updated bases from Debian 9 to 12
- Changed docker manifest to enable the proxy. (Couldn't install the docker images before)
- Both flags have been tested and work as intended.