### PR TITLE
Update proxmox template for Debian Bookworm

### DIFF
--- a/modules/bases/debian_bookworm_desktop_kde/secgen_metadata.xml
+++ b/modules/bases/debian_bookworm_desktop_kde/secgen_metadata.xml
@@ -17,7 +17,7 @@
   <url>https://app.vagrantup.com/secgen/boxes/bookworm-base/versions/1.0.1/providers/virtualbox/amd64/download/vagrant.box</url>
   <esxi_url>https://app.vagrantup.com/redwiz666/boxes/debian_stretch_desktop_kde/versions/1.0.0/providers/vmware.box</esxi_url>
   <ovirt_template>buster_desktop_kde_20230615</ovirt_template>
-  <proxmox_template>bookworm-desktop-kde-20241114</proxmox_template>
+  <proxmox_template>bookworm-desktop-kde-20260715</proxmox_template>
 
   <reference>https://atlas.hashicorp.com/puppetlabs</reference>
   <software_license>various</software_license>

--- a/modules/bases/kali_light_msf/secgen_metadata.xml
+++ b/modules/bases/kali_light_msf/secgen_metadata.xml
@@ -18,7 +18,7 @@
   <url>https://api.cloud.hashicorp.com/vagrant-archivist/v1/object/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJrZXkiOiJzZWNnZW4va2FsaV9saWdodC8yLjAuMS92aXJ0dWFsYm94LzY3NDYxYTBkLWNhZjMtMTFlZi05ZGIxLTIyMGFmOGE0NzQ3ZCIsIm1vZGUiOiJyIiwiZmlsZW5hbWUiOiJrYWxpX2xpZ2h0XzIuMC4xX3ZpcnR1YWxib3hfYW1kNjQuYm94In0.QNeeCdfTHvSP38idvSoBy0DHeR0tVLJ1yaN8JxLHUJE</url>
   <esxi_url></esxi_url>
   <ovirt_template>kali-linux-mfs-20231114</ovirt_template>
-  <proxmox_template>kali-linux-msf-20250108</proxmox_template>
+  <proxmox_template>kali-linux-msf-20260719</proxmox_template>
 
 
   <reference>https://app.vagrantup.com/secgen</reference>


### PR DESCRIPTION
Updated proxmox template for Debian Bookworm to use template which has patched CVE-2026-46331