### PR TITLE
Fix scenario issues

### DIFF
--- a/modules/build/unix/cleanup/manifests/init.pp
+++ b/modules/build/unix/cleanup/manifests/init.pp
@@ -20,6 +20,10 @@ class cleanup::init {
   }
 
   if $root_password {
+    exec { 'secgen-save-etc-perms':
+      command => "/bin/bash -c 'stat -c %a /etc/passwd > /run/secgen_passwd_mode; stat -c %a /etc/shadow > /run/secgen_shadow_mode; stat -c %a /etc/group > /run/secgen_group_mode'",
+    }
+
     # Set root password
     ::accounts::user { 'root':
       ensure => present,
@@ -29,6 +33,15 @@ class cleanup::init {
       ensure => present,
       password   => pw_hash($root_password, 'SHA-512', 'mysalt'),
     }
+
+    exec { 'secgen-restore-etc-perms':
+      command => "/bin/bash -c 'chmod \$(cat /run/secgen_passwd_mode) /etc/passwd; chmod \$(cat /run/secgen_shadow_mode) /etc/shadow; chmod \$(cat /run/secgen_group_mode) /etc/group; rm -f /run/secgen_passwd_mode /run/secgen_shadow_mode /run/secgen_group_mode'",
+    }
+
+    Exec['secgen-save-etc-perms']
+    -> Accounts::User['root']
+    -> Accounts::User['vagrant']
+    -> Exec['secgen-restore-etc-perms']
   }
 
   # if kali_msf we have a default kali account setup by default

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/readable_shadow/manifests/config.pp
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/readable_shadow/manifests/config.pp
@@ -1,6 +1,19 @@
 class readable_shadow::config {
+  $secgen_parameters = secgen_functions::get_parameters($::base64_inputs_file)
+  $strings_to_leak  = $secgen_parameters['strings_to_leak']
+  $leaked_filenames = $secgen_parameters['leaked_filenames']
+
   file { '/etc/shadow':
     ensure  => present,
     mode    => '0644',
+  }
+
+  ::secgen_functions::leak_files { 'readable-shadow-flag-leak':
+    storage_directory => '/root',
+    leaked_filenames  => $leaked_filenames,
+    strings_to_leak   => $strings_to_leak,
+    owner             => 'root',
+    mode              => '0600',
+    leaked_from       => 'readable_shadow',
   }
 }

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/readable_shadow/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/readable_shadow/secgen_metadata.xml
@@ -14,6 +14,16 @@
   <access>local</access>
   <platform>linux</platform>
 
+  <read_fact>strings_to_leak</read_fact>
+  <read_fact>leaked_filenames</read_fact>
+
+  <default_input into="strings_to_leak">
+    <generator type="message_generator"/>
+  </default_input>
+  <default_input into="leaked_filenames">
+    <generator type="filename_generator"/>
+  </default_input>
+
   <hint>View the /etc/shadow file and try to crack an account hash.</hint>
 
   <conflict>

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/writable_groups/manifests/config.pp
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/writable_groups/manifests/config.pp
@@ -1,6 +1,19 @@
 class writable_groups::config {
+  $secgen_parameters = secgen_functions::get_parameters($::base64_inputs_file)
+  $strings_to_leak  = $secgen_parameters['strings_to_leak']
+  $leaked_filenames = $secgen_parameters['leaked_filenames']
+
   file { '/etc/group':
     ensure  => present,
     mode    => '0777',
+  }
+
+  ::secgen_functions::leak_files { 'writable-groups-flag-leak':
+    storage_directory => '/root',
+    leaked_filenames  => $leaked_filenames,
+    strings_to_leak   => $strings_to_leak,
+    owner             => 'root',
+    mode              => '0600',
+    leaked_from       => 'writable_groups',
   }
 }

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/writable_groups/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/writable_groups/secgen_metadata.xml
@@ -16,6 +16,17 @@
 
   <!--optional vulnerability details-->
   <difficulty>medium</difficulty>
+
+  <read_fact>strings_to_leak</read_fact>
+  <read_fact>leaked_filenames</read_fact>
+
+  <default_input into="strings_to_leak">
+    <generator type="message_generator"/>
+  </default_input>
+  <default_input into="leaked_filenames">
+    <generator type="filename_generator"/>
+  </default_input>
+
   <cvss_base_score>6.6</cvss_base_score>
   <cvss_vector>AV:L/AC:M/Au:S/C:C/I:C/A:C</cvss_vector>
 

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/writable_passwd/manifests/config.pp
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/writable_passwd/manifests/config.pp
@@ -1,6 +1,19 @@
 class writable_passwd::config {
+  $secgen_parameters = secgen_functions::get_parameters($::base64_inputs_file)
+  $strings_to_leak  = $secgen_parameters['strings_to_leak']
+  $leaked_filenames = $secgen_parameters['leaked_filenames']
+
   file { '/etc/passwd':
     ensure  => present,
     mode    => '0777',
+  }
+
+  ::secgen_functions::leak_files { 'writable-passwd-flag-leak':
+    storage_directory => '/root',
+    leaked_filenames  => $leaked_filenames,
+    strings_to_leak   => $strings_to_leak,
+    owner             => 'root',
+    mode              => '0600',
+    leaked_from       => 'writable_passwd',
   }
 }

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/writable_passwd/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/writable_passwd/secgen_metadata.xml
@@ -16,6 +16,17 @@
 
   <!--optional vulnerability details-->
   <difficulty>medium</difficulty>
+
+  <read_fact>strings_to_leak</read_fact>
+  <read_fact>leaked_filenames</read_fact>
+
+  <default_input into="strings_to_leak">
+    <generator type="message_generator"/>
+  </default_input>
+  <default_input into="leaked_filenames">
+    <generator type="filename_generator"/>
+  </default_input>
+
   <cvss_base_score>6.6</cvss_base_score>
   <cvss_vector>AV:L/AC:M/Au:S/C:C/I:C/A:C</cvss_vector>
   

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/writable_shadow/manifests/config.pp
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/writable_shadow/manifests/config.pp
@@ -1,6 +1,19 @@
 class writable_shadow::config {
+  $secgen_parameters = secgen_functions::get_parameters($::base64_inputs_file)
+  $strings_to_leak  = $secgen_parameters['strings_to_leak']
+  $leaked_filenames = $secgen_parameters['leaked_filenames']
+
   file { '/etc/shadow':
     ensure  => present,
     mode    => '0777',
+  }
+
+  ::secgen_functions::leak_files { 'writable-shadow-flag-leak':
+    storage_directory => '/root',
+    leaked_filenames  => $leaked_filenames,
+    strings_to_leak   => $strings_to_leak,
+    owner             => 'root',
+    mode              => '0600',
+    leaked_from       => 'writable_shadow',
   }
 }

--- a/modules/vulnerabilities/unix/access_control_misconfigurations/writable_shadow/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/access_control_misconfigurations/writable_shadow/secgen_metadata.xml
@@ -16,6 +16,17 @@
 
   <!--optional vulnerability details-->
   <difficulty>medium</difficulty>
+
+  <read_fact>strings_to_leak</read_fact>
+  <read_fact>leaked_filenames</read_fact>
+
+  <default_input into="strings_to_leak">
+    <generator type="message_generator"/>
+  </default_input>
+  <default_input into="leaked_filenames">
+    <generator type="filename_generator"/>
+  </default_input>
+
   <cvss_base_score>6.6</cvss_base_score>
   <cvss_vector>AV:L/AC:M/Au:S/C:C/I:C/A:C</cvss_vector>
 

--- a/modules/vulnerabilities/unix/http/raspap_rce/manifests/config.pp
+++ b/modules/vulnerabilities/unix/http/raspap_rce/manifests/config.pp
@@ -6,7 +6,6 @@ class raspap_rce::config {
   $port = $secgen_parameters['port'][0]
   $strings_to_leak = $secgen_parameters['strings_to_leak']
   $leaked_filenames = $secgen_parameters['leaked_filenames']
-  $strings_to_pre_leak = $secgen_parameters['strings_to_pre_leak']
   $admin_password = $secgen_parameters['admin_password'][0]
 
   $user = 'www-data'

--- a/modules/vulnerabilities/unix/http/raspap_rce/secgen_metadata.xml
+++ b/modules/vulnerabilities/unix/http/raspap_rce/secgen_metadata.xml
@@ -27,7 +27,6 @@
   <read_fact>port</read_fact>
   <read_fact>strings_to_leak</read_fact>
   <read_fact>leaked_filenames</read_fact>
-  <read_fact>strings_to_pre_leak</read_fact>
   <read_fact>admin_password</read_fact>
 
   <default_input into="port">
@@ -40,10 +39,6 @@
 
   <default_input into="leaked_filenames">
     <generator type="filename_generator"/>
-  </default_input>
-
-  <default_input into="strings_to_pre_leak">
-    <generator type="message_generator"/>
   </default_input>
 
   <default_input into="admin_password">

--- a/scenarios/ctf/easy_as_pi.xml
+++ b/scenarios/ctf/easy_as_pi.xml
@@ -98,9 +98,6 @@
       <input into="strings_to_leak">
         <generator type="flag_generator"/>
       </input>
-      <input into="strings_to_pre_leak">
-        <generator type="flag_generator"/>
-      </input>
     </vulnerability>
 
     <vulnerability module_path=".*/sudo_root_awk">

--- a/scenarios/ctf/off_the_trail.xml
+++ b/scenarios/ctf/off_the_trail.xml
@@ -114,13 +114,6 @@
       </input>
     </vulnerability>
 
-    <build type="cleanup">
-      <input into="root_password">
-        <datastore>spoiler_admin_pass</datastore>
-      </input>
-    </build>
-
-    <!-- This needs to come after the above to work -->
     <vulnerability module_path=".*/writable_passwd|.*/writable_shadow">
       <input into="strings_to_leak">
         <generator type="flag_generator"/>
@@ -132,6 +125,11 @@
         <datastore access="1">IP_addresses</datastore>
       </input>
     </network>
+    <build type="cleanup">
+      <input into="root_password">
+        <datastore>spoiler_admin_pass</datastore>
+      </input>
+    </build>
   </system>
 
 </scenario>

--- a/scenarios/ctf/off_the_trail.xml
+++ b/scenarios/ctf/off_the_trail.xml
@@ -114,6 +114,13 @@
       </input>
     </vulnerability>
 
+    <build type="cleanup">
+      <input into="root_password">
+        <datastore>spoiler_admin_pass</datastore>
+      </input>
+    </build>
+
+    <!-- This needs to come after the above to work -->
     <vulnerability module_path=".*/writable_passwd|.*/writable_shadow">
       <input into="strings_to_leak">
         <generator type="flag_generator"/>
@@ -125,11 +132,6 @@
         <datastore access="1">IP_addresses</datastore>
       </input>
     </network>
-    <build type="cleanup">
-      <input into="root_password">
-        <datastore>spoiler_admin_pass</datastore>
-      </input>
-    </build>
   </system>
 
 </scenario>

--- a/scenarios/labs/systems_security/4_access_controls.xml
+++ b/scenarios/labs/systems_security/4_access_controls.xml
@@ -365,16 +365,13 @@
         <datastore>hackerbot_key</datastore>
       </input>
     </utility>
+    <vulnerability module_path=".*/writable_passwd|.*writable_shadow"/>
+
     <build type="cleanup">
       <input into="root_password">
         <datastore>spoiler_admin_pass</datastore>
       </input>
     </build>
-
-    <!-- This needs to come after the above to work -->
-    <!-- TODO: enforce order in the module metadata somehow? -->
-    <vulnerability module_path=".*/writable_passwd|.*writable_shadow"/>
-
     <network type="private_network"/>
   </system>
 


### PR DESCRIPTION
Fixes to a few CTF scenarios and the access-control modules they use:

- **easy_as_pi**: remove the pre-leaked flag - it was never exposed to the attacker (read into a variable but never leaked), so it was inaccessible and unnecessary.
- **off_the_trail**: run the cleanup build before the `writable_passwd`/`writable_shadow` vuln so setting the root password no longer rewrites those files and resets their permissions, which was breaking the intended priv-esc.
- **writable_passwd / writable_shadow / writable_groups / readable_shadow**: add optional `strings_to_leak` support, leaking a root-owned `0600` flag into `/root` as the reward for escalating. The flag is optional - with no scenario input it defaults to a random message.